### PR TITLE
Smdn.MSBuild.ProjectAssets.Commonを導入する

### DIFF
--- a/eng/BuildAllProjects.ps1
+++ b/eng/BuildAllProjects.ps1
@@ -6,6 +6,9 @@ $RepositoryRootDirectory = [System.IO.Path]::GetFullPath(
   [System.IO.Path]::Join($PSScriptRoot, "../")
 )
 
+# download Smdn.MSBuild.ProjectAssets.* first
+dotnet restore $([System.IO.Path]::Join($RepositoryRootDirectory, 'eng', 'InstallProjectAssets.proj'))
+
 # create a solution for the build target projects
 Set-Location $RepositoryRootDirectory
 

--- a/eng/InstallProjectAssets.proj
+++ b/eng/InstallProjectAssets.proj
@@ -1,0 +1,20 @@
+<!--
+SPDX-FileCopyrightText: 2022 smdn <smdn@smdn.jp>
+SPDX-License-Identifier: MIT
+-->
+<!--
+  This project file performs downloading packages defined by PackageDownload.
+  Run `dotnet restore` to download the packages.
+-->
+<Project Sdk="Microsoft.Build.NoTargets/1.0.80">
+  <Import Project="$(MSBuildThisFileDirectory)..\src\Directory.Build.props" />
+
+  <!-- ref: https://learn.microsoft.com/en-us/nuget/consume-packages/packagedownload-functionality -->
+  <PropertyGroup>
+    <NoBuild>true</NoBuild>
+    <TargetFramework>netstandard1.0</TargetFramework>
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\src\Directory.Build.targets" />
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -36,7 +36,6 @@ SPDX-License-Identifier: MIT
     <NoWarn>CA1008;$(NoWarn)</NoWarn> <!-- CA1008: 提案された名前 'None' を伴う、値 0 を含む メンバーを追加します -->
     <NoWarn>CA1031;$(NoWarn)</NoWarn> <!-- CA1031: 'Dispose' を変更してより具体的な許可された例外の種類をキャッチするか、例外を再スローしてください -->
     <NoWarn>CA1063;$(NoWarn)</NoWarn> <!-- CA1063: Dispose(bool) のオーバーライド可能な実装を提供するか、型を sealed としてマークします。Dispose(false) を呼び出す場合は、ネイティブ リソースのみがクリーンアップされます。Dispose(true) を呼び出す場合には、マネージド リソースとネイティブ リソースの両方がクリーンアップされます。  -->
-    <NoWarn>CA1305;$(NoWarn)</NoWarn> <!-- CA1305:現在のユーザーのロケール設定によって異なる場合があります。 -->
     <NoWarn>CA1708;$(NoWarn)</NoWarn> <!-- CA1708: 名前は、大文字と小文字の区別以外にも相違させる必要があります -->
     <NoWarn>CA1716;$(NoWarn)</NoWarn> <!-- CA1716: 予約されている言語キーワードと競合しないようにしてください。-->
     <NoWarn>CA1721;$(NoWarn)</NoWarn> <!-- CA1721: メソッドの存在が指定されているため、プロパティ名は混乱を招きます。-->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,6 +17,7 @@ SPDX-License-Identifier: MIT
   </PropertyGroup>
 
   <PropertyGroup Label="package properties">
+    <Authors>HiroyukiSakoh,smdn</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</PackageProjectUrl>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,55 @@
+<!--
+SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+SPDX-License-Identifier: MIT
+-->
+<Project>
+  <PropertyGroup>
+    <SmdnBuildAssetRootDirectory>$(MSBuildThisFileDirectory)..\</SmdnBuildAssetRootDirectory>
+  </PropertyGroup>
+
+  <ImportGroup Label="project assets">
+    <Import Project="$(MSBuildThisFileDirectory)ProjectAssets.props" />
+  </ImportGroup>
+
+  <PropertyGroup Label="API list generator configurations">
+    <APIListOutputBaseDirectory>$(MSBuildThisFileDirectory)..\doc\api-list\</APIListOutputBaseDirectory>
+    <APIListPackageVersion>1.4.0</APIListPackageVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Label="package properties">
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</PackageProjectUrl>
+  </PropertyGroup>
+
+  <PropertyGroup Label="repository properties" Condition="'$(GITHUB_ACTIONS)' != 'true'">
+    <RepositoryUrl>https://github.com/smdn/Smdn.Net.EchonetLite</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
+  <!-- disables code style/code analysis warnings -->
+  <PropertyGroup>
+    <NoWarn>IDE0005;$(NoWarn)</NoWarn> <!-- IDE0005: Using ディレクティブは必要ありません。 -->
+    <NoWarn>IDE0040;$(NoWarn)</NoWarn> <!-- IDE0040: アクセシビリティ修飾子が必要です -->
+    <NoWarn>IDE0048;$(NoWarn)</NoWarn> <!-- IDE0048: わかりやすくするためにかっこを追加してください -->
+    <NoWarn>IDE0055;$(NoWarn)</NoWarn> <!-- IDE0055: 書式設定を修正 -->
+    <NoWarn>IDE0059;$(NoWarn)</NoWarn> <!-- IDE0059: 値の不必要な代入 -->
+    <NoWarn>IDE0060;$(NoWarn)</NoWarn> <!-- IDE0060: 未使用のパラメーターを削除 -->
+    <NoWarn>IDE0090;$(NoWarn)</NoWarn> <!-- IDE0090: 'new' 式を簡素化できます -->
+    <NoWarn>IDE0161;$(NoWarn)</NoWarn> <!-- IDE0161: 範囲指定されたファイルが設定された namespace に変換 -->
+    <NoWarn>IDE1006;$(NoWarn)</NoWarn> <!-- IDE1006: 名前付けルール違反 -->
+    <NoWarn>CA1008;$(NoWarn)</NoWarn> <!-- CA1008: 提案された名前 'None' を伴う、値 0 を含む メンバーを追加します -->
+    <NoWarn>CA1031;$(NoWarn)</NoWarn> <!-- CA1031: 'Dispose' を変更してより具体的な許可された例外の種類をキャッチするか、例外を再スローしてください -->
+    <NoWarn>CA1063;$(NoWarn)</NoWarn> <!-- CA1063: Dispose(bool) のオーバーライド可能な実装を提供するか、型を sealed としてマークします。Dispose(false) を呼び出す場合は、ネイティブ リソースのみがクリーンアップされます。Dispose(true) を呼び出す場合には、マネージド リソースとネイティブ リソースの両方がクリーンアップされます。  -->
+    <NoWarn>CA1305;$(NoWarn)</NoWarn> <!-- CA1305:現在のユーザーのロケール設定によって異なる場合があります。 -->
+    <NoWarn>CA1708;$(NoWarn)</NoWarn> <!-- CA1708: 名前は、大文字と小文字の区別以外にも相違させる必要があります -->
+    <NoWarn>CA1716;$(NoWarn)</NoWarn> <!-- CA1716: 予約されている言語キーワードと競合しないようにしてください。-->
+    <NoWarn>CA1721;$(NoWarn)</NoWarn> <!-- CA1721: メソッドの存在が指定されているため、プロパティ名は混乱を招きます。-->
+    <NoWarn>CA1725;$(NoWarn)</NoWarn> <!-- CA1725: 宣言されている識別子と一致するように、メンバーのパラメーター名を変更してください-->
+    <NoWarn>CA1812;$(NoWarn)</NoWarn> <!-- CA1812: 明らかにインスタンス化されない内部クラスです。 -->
+    <NoWarn>CA1816;$(NoWarn)</NoWarn> <!-- CA1816: GC.SuppressFinalize(object) を呼び出すように Dispose() を変更します。これにより、ファイナライザーを導入する派生型で、その呼び出しのために 'IDisposable' を再実装する必要がなくなります。-->
+    <NoWarn>CA1848;$(NoWarn)</NoWarn> <!-- CA1848: パフォーマンスを向上させるには、LoggerMessage デリゲートを使用します -->
+    <NoWarn>CA1851;$(NoWarn)</NoWarn> <!-- CA1851: 'IEnumerable' コレクションを複数列挙している可能性があります。複数列挙を回避する実装を検討してください。 -->
+    <NoWarn>CA2213;$(NoWarn)</NoWarn> <!-- CA2213: Dispose メソッドを変更して、このフィールドで Close または Dispose を呼び出します。 -->
+    <NoWarn>CA2254;$(NoWarn)</NoWarn> <!-- CA2254: ログ メッセージ テンプレートは、LoggerExtensions.Log****(ILogger, string?, params object?[])' への呼び出しによって異なるべきではありません。 -->
+  </PropertyGroup>
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,7 +30,6 @@ SPDX-License-Identifier: MIT
   <PropertyGroup>
     <NoWarn>IDE0005;$(NoWarn)</NoWarn> <!-- IDE0005: Using ディレクティブは必要ありません。 -->
     <NoWarn>IDE0040;$(NoWarn)</NoWarn> <!-- IDE0040: アクセシビリティ修飾子が必要です -->
-    <NoWarn>IDE0048;$(NoWarn)</NoWarn> <!-- IDE0048: わかりやすくするためにかっこを追加してください -->
     <NoWarn>IDE0055;$(NoWarn)</NoWarn> <!-- IDE0055: 書式設定を修正 -->
     <NoWarn>IDE0059;$(NoWarn)</NoWarn> <!-- IDE0059: 値の不必要な代入 -->
     <NoWarn>IDE0060;$(NoWarn)</NoWarn> <!-- IDE0060: 未使用のパラメーターを削除 -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,7 +31,6 @@ SPDX-License-Identifier: MIT
     <NoWarn>IDE0005;$(NoWarn)</NoWarn> <!-- IDE0005: Using ディレクティブは必要ありません。 -->
     <NoWarn>IDE0040;$(NoWarn)</NoWarn> <!-- IDE0040: アクセシビリティ修飾子が必要です -->
     <NoWarn>IDE0055;$(NoWarn)</NoWarn> <!-- IDE0055: 書式設定を修正 -->
-    <NoWarn>IDE0090;$(NoWarn)</NoWarn> <!-- IDE0090: 'new' 式を簡素化できます -->
     <NoWarn>IDE0161;$(NoWarn)</NoWarn> <!-- IDE0161: 範囲指定されたファイルが設定された namespace に変換 -->
     <NoWarn>IDE1006;$(NoWarn)</NoWarn> <!-- IDE1006: 名前付けルール違反 -->
     <NoWarn>CA1008;$(NoWarn)</NoWarn> <!-- CA1008: 提案された名前 'None' を伴う、値 0 を含む メンバーを追加します -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,7 +31,6 @@ SPDX-License-Identifier: MIT
     <NoWarn>IDE0005;$(NoWarn)</NoWarn> <!-- IDE0005: Using ディレクティブは必要ありません。 -->
     <NoWarn>IDE0040;$(NoWarn)</NoWarn> <!-- IDE0040: アクセシビリティ修飾子が必要です -->
     <NoWarn>IDE0055;$(NoWarn)</NoWarn> <!-- IDE0055: 書式設定を修正 -->
-    <NoWarn>IDE0059;$(NoWarn)</NoWarn> <!-- IDE0059: 値の不必要な代入 -->
     <NoWarn>IDE0060;$(NoWarn)</NoWarn> <!-- IDE0060: 未使用のパラメーターを削除 -->
     <NoWarn>IDE0090;$(NoWarn)</NoWarn> <!-- IDE0090: 'new' 式を簡素化できます -->
     <NoWarn>IDE0161;$(NoWarn)</NoWarn> <!-- IDE0161: 範囲指定されたファイルが設定された namespace に変換 -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -41,7 +41,6 @@ SPDX-License-Identifier: MIT
     <NoWarn>CA1725;$(NoWarn)</NoWarn> <!-- CA1725: 宣言されている識別子と一致するように、メンバーのパラメーター名を変更してください-->
     <NoWarn>CA1816;$(NoWarn)</NoWarn> <!-- CA1816: GC.SuppressFinalize(object) を呼び出すように Dispose() を変更します。これにより、ファイナライザーを導入する派生型で、その呼び出しのために 'IDisposable' を再実装する必要がなくなります。-->
     <NoWarn>CA1848;$(NoWarn)</NoWarn> <!-- CA1848: パフォーマンスを向上させるには、LoggerMessage デリゲートを使用します -->
-    <NoWarn>CA1851;$(NoWarn)</NoWarn> <!-- CA1851: 'IEnumerable' コレクションを複数列挙している可能性があります。複数列挙を回避する実装を検討してください。 -->
     <NoWarn>CA2213;$(NoWarn)</NoWarn> <!-- CA2213: Dispose メソッドを変更して、このフィールドで Close または Dispose を呼び出します。 -->
     <NoWarn>CA2254;$(NoWarn)</NoWarn> <!-- CA2254: ログ メッセージ テンプレートは、LoggerExtensions.Log****(ILogger, string?, params object?[])' への呼び出しによって異なるべきではありません。 -->
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,7 +31,6 @@ SPDX-License-Identifier: MIT
     <NoWarn>IDE0005;$(NoWarn)</NoWarn> <!-- IDE0005: Using ディレクティブは必要ありません。 -->
     <NoWarn>IDE0040;$(NoWarn)</NoWarn> <!-- IDE0040: アクセシビリティ修飾子が必要です -->
     <NoWarn>IDE0055;$(NoWarn)</NoWarn> <!-- IDE0055: 書式設定を修正 -->
-    <NoWarn>IDE0060;$(NoWarn)</NoWarn> <!-- IDE0060: 未使用のパラメーターを削除 -->
     <NoWarn>IDE0090;$(NoWarn)</NoWarn> <!-- IDE0090: 'new' 式を簡素化できます -->
     <NoWarn>IDE0161;$(NoWarn)</NoWarn> <!-- IDE0161: 範囲指定されたファイルが設定された namespace に変換 -->
     <NoWarn>IDE1006;$(NoWarn)</NoWarn> <!-- IDE1006: 名前付けルール違反 -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,7 +28,6 @@ SPDX-License-Identifier: MIT
 
   <!-- disables code style/code analysis warnings -->
   <PropertyGroup>
-    <NoWarn>IDE0040;$(NoWarn)</NoWarn> <!-- IDE0040: アクセシビリティ修飾子が必要です -->
     <NoWarn>IDE0055;$(NoWarn)</NoWarn> <!-- IDE0055: 書式設定を修正 -->
     <NoWarn>IDE0161;$(NoWarn)</NoWarn> <!-- IDE0161: 範囲指定されたファイルが設定された namespace に変換 -->
     <NoWarn>IDE1006;$(NoWarn)</NoWarn> <!-- IDE1006: 名前付けルール違反 -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,7 +35,6 @@ SPDX-License-Identifier: MIT
     <NoWarn>CA1031;$(NoWarn)</NoWarn> <!-- CA1031: 'Dispose' を変更してより具体的な許可された例外の種類をキャッチするか、例外を再スローしてください -->
     <NoWarn>CA1063;$(NoWarn)</NoWarn> <!-- CA1063: Dispose(bool) のオーバーライド可能な実装を提供するか、型を sealed としてマークします。Dispose(false) を呼び出す場合は、ネイティブ リソースのみがクリーンアップされます。Dispose(true) を呼び出す場合には、マネージド リソースとネイティブ リソースの両方がクリーンアップされます。  -->
     <NoWarn>CA1716;$(NoWarn)</NoWarn> <!-- CA1716: 予約されている言語キーワードと競合しないようにしてください。-->
-    <NoWarn>CA1721;$(NoWarn)</NoWarn> <!-- CA1721: メソッドの存在が指定されているため、プロパティ名は混乱を招きます。-->
     <NoWarn>CA1725;$(NoWarn)</NoWarn> <!-- CA1725: 宣言されている識別子と一致するように、メンバーのパラメーター名を変更してください-->
     <NoWarn>CA1816;$(NoWarn)</NoWarn> <!-- CA1816: GC.SuppressFinalize(object) を呼び出すように Dispose() を変更します。これにより、ファイナライザーを導入する派生型で、その呼び出しのために 'IDisposable' を再実装する必要がなくなります。-->
     <NoWarn>CA1848;$(NoWarn)</NoWarn> <!-- CA1848: パフォーマンスを向上させるには、LoggerMessage デリゲートを使用します -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,6 +20,7 @@ SPDX-License-Identifier: MIT
     <Authors>HiroyukiSakoh,smdn</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</PackageProjectUrl>
+    <PackageTags>ECHONET;ECHONET-Lite</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup Label="repository properties" Condition="'$(GITHUB_ACTIONS)' != 'true'">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,7 +39,6 @@ SPDX-License-Identifier: MIT
     <NoWarn>CA1716;$(NoWarn)</NoWarn> <!-- CA1716: 予約されている言語キーワードと競合しないようにしてください。-->
     <NoWarn>CA1721;$(NoWarn)</NoWarn> <!-- CA1721: メソッドの存在が指定されているため、プロパティ名は混乱を招きます。-->
     <NoWarn>CA1725;$(NoWarn)</NoWarn> <!-- CA1725: 宣言されている識別子と一致するように、メンバーのパラメーター名を変更してください-->
-    <NoWarn>CA1812;$(NoWarn)</NoWarn> <!-- CA1812: 明らかにインスタンス化されない内部クラスです。 -->
     <NoWarn>CA1816;$(NoWarn)</NoWarn> <!-- CA1816: GC.SuppressFinalize(object) を呼び出すように Dispose() を変更します。これにより、ファイナライザーを導入する派生型で、その呼び出しのために 'IDisposable' を再実装する必要がなくなります。-->
     <NoWarn>CA1848;$(NoWarn)</NoWarn> <!-- CA1848: パフォーマンスを向上させるには、LoggerMessage デリゲートを使用します -->
     <NoWarn>CA1851;$(NoWarn)</NoWarn> <!-- CA1851: 'IEnumerable' コレクションを複数列挙している可能性があります。複数列挙を回避する実装を検討してください。 -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,6 +26,10 @@ SPDX-License-Identifier: MIT
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
+  <PropertyGroup Label="assembly attributes">
+    <Copyright Condition=" '$(Copyright)' == '' ">Copyright © 2018 HiroyukiSakoh, Copyright © 2023 smdn.</Copyright>
+  </PropertyGroup>
+
   <!-- disables code style/code analysis warnings -->
   <PropertyGroup>
     <NoWarn>IDE0055;$(NoWarn)</NoWarn> <!-- IDE0055: 書式設定を修正 -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,7 +28,6 @@ SPDX-License-Identifier: MIT
 
   <!-- disables code style/code analysis warnings -->
   <PropertyGroup>
-    <NoWarn>IDE0005;$(NoWarn)</NoWarn> <!-- IDE0005: Using ディレクティブは必要ありません。 -->
     <NoWarn>IDE0040;$(NoWarn)</NoWarn> <!-- IDE0040: アクセシビリティ修飾子が必要です -->
     <NoWarn>IDE0055;$(NoWarn)</NoWarn> <!-- IDE0055: 書式設定を修正 -->
     <NoWarn>IDE0161;$(NoWarn)</NoWarn> <!-- IDE0161: 範囲指定されたファイルが設定された namespace に変換 -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -36,7 +36,6 @@ SPDX-License-Identifier: MIT
     <NoWarn>CA1008;$(NoWarn)</NoWarn> <!-- CA1008: 提案された名前 'None' を伴う、値 0 を含む メンバーを追加します -->
     <NoWarn>CA1031;$(NoWarn)</NoWarn> <!-- CA1031: 'Dispose' を変更してより具体的な許可された例外の種類をキャッチするか、例外を再スローしてください -->
     <NoWarn>CA1063;$(NoWarn)</NoWarn> <!-- CA1063: Dispose(bool) のオーバーライド可能な実装を提供するか、型を sealed としてマークします。Dispose(false) を呼び出す場合は、ネイティブ リソースのみがクリーンアップされます。Dispose(true) を呼び出す場合には、マネージド リソースとネイティブ リソースの両方がクリーンアップされます。  -->
-    <NoWarn>CA1708;$(NoWarn)</NoWarn> <!-- CA1708: 名前は、大文字と小文字の区別以外にも相違させる必要があります -->
     <NoWarn>CA1716;$(NoWarn)</NoWarn> <!-- CA1716: 予約されている言語キーワードと競合しないようにしてください。-->
     <NoWarn>CA1721;$(NoWarn)</NoWarn> <!-- CA1721: メソッドの存在が指定されているため、プロパティ名は混乱を招きます。-->
     <NoWarn>CA1725;$(NoWarn)</NoWarn> <!-- CA1725: 宣言されている識別子と一致するように、メンバーのパラメーター名を変更してください-->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+SPDX-License-Identifier: MIT
+-->
+<Project>
+  <ImportGroup Label="project assets">
+    <Import Project="$(SmdnProjectAssets_TargetsImports)" />
+  </ImportGroup>
+</Project>

--- a/src/ProjectAssets.props
+++ b/src/ProjectAssets.props
@@ -1,0 +1,60 @@
+<!--
+SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+SPDX-License-Identifier: MIT
+-->
+<Project>
+  <PropertyGroup>
+    <SmdnProjectAssets_Common_PackageVersion Condition=" '$(SmdnProjectAssets_Common_PackageVersion)' == '' ">1.4.0</SmdnProjectAssets_Common_PackageVersion>
+    <!-- <SmdnProjectAssets_Library_PackageVersion Condition=" '$(SmdnProjectAssets_Library_PackageVersion)' == '' ">1.7.1</SmdnProjectAssets_Library_PackageVersion> -->
+  </PropertyGroup>
+
+  <!--
+    NuGetPackageRoot is not set until `pack` or `restore` is executed, so set an alternative default path here
+    ref: https://github.com/NuGet/Home/issues/9150
+  -->
+  <PropertyGroup>
+    <_NuGetPackageAltRoot>$(NuGetPackageRoot)</_NuGetPackageAltRoot>
+    <_NuGetPackageAltRoot Condition="('$(_NuGetPackageAltRoot)' == '') and ('$(NUGET_PACKAGES)' != '')">$(NUGET_PACKAGES)\</_NuGetPackageAltRoot>
+    <_NuGetPackageAltRoot Condition="('$(_NuGetPackageAltRoot)' == '') and $([MSBuild]::IsOSUnixLike())">$(HOME)\.nuget\packages\</_NuGetPackageAltRoot>
+    <_NuGetPackageAltRoot Condition="('$(_NuGetPackageAltRoot)' == '')">$(USERPROFILE)\.nuget\packages\</_NuGetPackageAltRoot>
+  </PropertyGroup>
+
+  <!--
+    Set the path to *.props/*targets files of asset library according to the switching property.
+  -->
+  <PropertyGroup>
+    <_SmdnProjectAssets_Common_PathToPackageRoot Condition=" '$(_SmdnProjectAssets_Common_PathToPackageRoot)' == '' ">$(_NuGetPackageAltRoot)smdn.msbuild.projectassets.common\$(SmdnProjectAssets_Common_PackageVersion)\</_SmdnProjectAssets_Common_PathToPackageRoot>
+    <!-- <_SmdnProjectAssets_Library_PathToPackageRoot Condition=" '$(_SmdnProjectAssets_Library_PathToPackageRoot)' == '' ">$(_NuGetPackageAltRoot)smdn.msbuild.projectassets.library\$(SmdnProjectAssets_Library_PackageVersion)\</_SmdnProjectAssets_Library_PathToPackageRoot> -->
+  </PropertyGroup>
+
+  <!--
+    Importing by *.nuget.g.props/*.nuget.g.targets file does not properly set the properties defined in the asset library,
+    so do not use PackageReference with IncludeAssets, and import *.props/*targets manually instead.
+  -->
+  <ItemGroup>
+    <PackageDownload
+      Include="Smdn.MSBuild.ProjectAssets.Common"
+      Version="[$(SmdnProjectAssets_Common_PackageVersion)]"
+    />
+    <!--
+    <PackageDownload
+      Include="Smdn.MSBuild.ProjectAssets.Library"
+      Version="[$(SmdnProjectAssets_Library_PackageVersion)]"
+    />
+    -->
+  </ItemGroup>
+
+  <!--
+    Import *.props files.
+  -->
+  <Import Project="$(_SmdnProjectAssets_Common_PathToPackageRoot)project\Project.props" />
+  <!-- <Import Project="$(_SmdnProjectAssets_Library_PathToPackageRoot)project\Project.props" /> -->
+
+  <!--
+    Define the path to *.targets files to be imported.
+  -->
+  <PropertyGroup>
+    <SmdnProjectAssets_TargetsImports>$(SmdnProjectAssets_TargetsImports);$(_SmdnProjectAssets_Common_PathToPackageRoot)project\Project.targets</SmdnProjectAssets_TargetsImports>
+    <!-- <SmdnProjectAssets_TargetsImports>$(SmdnProjectAssets_TargetsImports);$(_SmdnProjectAssets_Library_PathToPackageRoot)project\Project.targets</SmdnProjectAssets_TargetsImports> -->
+  </PropertyGroup>
+</Project>

--- a/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/EchoClassGroup.cs
+++ b/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/EchoClassGroup.cs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: MIT
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Text.Json.Serialization;
 
 namespace EchoDotNetLite.Specifications

--- a/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/EchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/EchonetObject.cs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: MIT
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 
 namespace EchoDotNetLite.Specifications

--- a/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/JsonConverter.cs
+++ b/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/JsonConverter.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2018 HiroyukiSakoh
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
+#pragma warning disable CA1812
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/JsonConverter.cs
+++ b/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/JsonConverter.cs
@@ -4,9 +4,7 @@
 #pragma warning disable CA1812
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/PropertyMaster.cs
+++ b/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/PropertyMaster.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2018 HiroyukiSakoh
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
+#pragma warning disable CA1812
+
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;

--- a/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/SpecificationMaster.cs
+++ b/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/SpecificationMaster.cs
@@ -6,9 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/SpecificationMaster.cs
+++ b/src/Smdn.Net.EchonetLite.Specifications/EchoDotNetLite.Specifications/SpecificationMaster.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2018 HiroyukiSakoh
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
+#pragma warning disable CA1812
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Smdn.Net.EchonetLite.Specifications/Smdn.Net.EchonetLite.Specifications.csproj
+++ b/src/Smdn.Net.EchonetLite.Specifications/Smdn.Net.EchonetLite.Specifications.csproj
@@ -7,6 +7,8 @@ SPDX-License-Identifier: MIT
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Common/CollectionChangeType.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Common/CollectionChangeType.cs
@@ -9,9 +9,11 @@ using System.Text;
 namespace EchoDotNetLite.Common
 {
     [Obsolete($"Use {nameof(NotifyCollectionChangedEventArgs)} instead.")]
+#pragma warning disable CA1008
     public enum CollectionChangeType
     {
         Add = 1,
         Remove = 2,
     }
+#pragma warning restore CA1008
 }

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Common/CollectionChangeType.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Common/CollectionChangeType.cs
@@ -2,9 +2,7 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
 using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Text;
 
 namespace EchoDotNetLite.Common
 {

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Common/Extentions.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Common/Extentions.cs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: MIT
 using EchoDotNetLite.Models;
 using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Common/Extentions.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Common/Extentions.cs
@@ -36,7 +36,7 @@ namespace EchoDotNetLite.Common
                 return "Spec null";
             }
             var sb = new StringBuilder();
-            sb.Append($"0x{echoPropertyInstance.Spec.Code:X2}");
+            sb.AppendFormat(provider: null, "0x{0:X2}", echoPropertyInstance.Spec.Code);
             sb.Append(echoPropertyInstance.Spec.Name);
             sb.Append(' ');
             sb.Append(echoPropertyInstance.Get ? "Get" : "");

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Enums/EHD1.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Enums/EHD1.cs
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2018 HiroyukiSakoh
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace EchoDotNetLite.Enums
 {
     public enum EHD1 : byte

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Enums/EHD2.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Enums/EHD2.cs
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2018 HiroyukiSakoh
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace EchoDotNetLite.Enums
 {
     public enum EHD2 : byte

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Enums/ESV.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Enums/ESV.cs
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2018 HiroyukiSakoh
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace EchoDotNetLite.Enums
 {
     public enum ESV : byte

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EDATA1.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EDATA1.cs
@@ -107,7 +107,7 @@ namespace EchoDotNetLite.Models
 #endif
         public bool IsWriteOrReadService => FrameSerializer.IsESVWriteOrReadService(ESV);
 
-        public IReadOnlyCollection<PropertyRequest> GetOPCList()
+        internal IReadOnlyCollection<PropertyRequest> GetOPCList()
         {
             if (IsWriteOrReadService)
                 throw new InvalidOperationException($"invalid operation for the ESV of the current instance (ESV={ESV})");

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EDATA1.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EDATA1.cs
@@ -5,10 +5,10 @@ using EchoDotNetLite.Enums;
 using EchoDotNetLite.Serialization;
 using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
+#endif
 using System.Text.Json.Serialization;
-using static EchoDotNetLite.Models.Frame;
 
 namespace EchoDotNetLite.Models
 {

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EDATA2.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EDATA2.cs
@@ -2,8 +2,6 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace EchoDotNetLite.Models
 {

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EOJ.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EOJ.cs
@@ -1,11 +1,8 @@
 // SPDX-FileCopyrightText: 2018 HiroyukiSakoh
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
-using EchoDotNetLite.Enums;
 using EchoDotNetLite.Serialization;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Text.Json.Serialization;
 
 namespace EchoDotNetLite.Models

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EchoNode.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EchoNode.cs
@@ -4,13 +4,11 @@
 using EchoDotNetLite.Common;
 using EchoDotNetLite.Specifications;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net;
-using System.Text;
 
 namespace EchoDotNetLite.Models
 {

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EchoObjectInstance.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EchoObjectInstance.cs
@@ -16,7 +16,9 @@ namespace EchoDotNetLite.Models
     /// <summary>
     /// ECHONET Lite オブジェクトインスタンス
     /// </summary>
+#pragma warning disable CA1708
     public sealed class EchoObjectInstance
+#pragma warning restore CA1708
     {
         /// <summary>
         /// デフォルトコンストラクタ
@@ -149,26 +151,31 @@ namespace EchoDotNetLite.Models
         /// <summary>
         /// GETプロパティの一覧
         /// </summary>
+#pragma warning disable CA1708
         public IEnumerable<EchoPropertyInstance> GetProperties => Properties.Where(static p => p.Spec.Get);
 
         [Obsolete($"Use {nameof(GetProperties)} instead.")]
         public IEnumerable<EchoPropertyInstance> GETProperties => GetProperties;
+#pragma warning restore CA1708
 
         /// <summary>
         /// SETプロパティの一覧
         /// </summary>
+#pragma warning disable CA1708
         public IEnumerable<EchoPropertyInstance> SetProperties => Properties.Where(static p => p.Spec.Set);
 
         [Obsolete($"Use {nameof(SetProperties)} instead.")]
         public IEnumerable<EchoPropertyInstance> SETProperties => SetProperties;
+#pragma warning restore CA1708
 
         /// <summary>
         /// ANNOプロパティの一覧
         /// </summary>
+#pragma warning disable CA1708
         public IEnumerable<EchoPropertyInstance> AnnoProperties => Properties.Where(static p => p.Spec.Anno);
 
         [Obsolete($"Use {nameof(AnnoProperties)} instead.")]
         public IEnumerable<EchoPropertyInstance> ANNOProperties => AnnoProperties;
-
+#pragma warning restore CA1708
     }
 }

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EchoObjectInstance.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EchoObjectInstance.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
 using EchoDotNetLite.Common;
 using EchoDotNetLite.Specifications;
 

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EchoPropertyInstance.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EchoPropertyInstance.cs
@@ -3,10 +3,6 @@
 // SPDX-License-Identifier: MIT
 using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace EchoDotNetLite.Models
 {

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EchoPropertyInstance.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/EchoPropertyInstance.cs
@@ -17,7 +17,7 @@ namespace EchoDotNetLite.Models
     public sealed class EchoPropertyInstance
     {
         internal static Specifications.EchoProperty GenerateUnknownProperty(byte epc)
-            => new Specifications.EchoProperty
+            => new
             (
                 code: epc,
                 name: "Unknown",

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/Frame.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/Frame.cs
@@ -4,8 +4,6 @@
 using EchoDotNetLite.Enums;
 using EchoDotNetLite.Serialization;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Text.Json.Serialization;
 
 namespace EchoDotNetLite.Models

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/IEDATA.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/IEDATA.cs
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2018 HiroyukiSakoh
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace EchoDotNetLite.Models
 {
     public interface IEDATA

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/PropertyRequest.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Models/PropertyRequest.cs
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: MIT
 using EchoDotNetLite.Serialization;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Text.Json.Serialization;
 
 namespace EchoDotNetLite.Models

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Serialization/ByteSequenceJsonConverter.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Serialization/ByteSequenceJsonConverter.cs
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
+#pragma warning disable CA1812
+
 using System;
 using System.Text;
 using System.Text.Json;

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Serialization/SingleByteJsonConverter.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Serialization/SingleByteJsonConverter.cs
@@ -12,7 +12,7 @@ internal sealed class SingleByteJsonConverter<TByte> : JsonConverter<TByte>
     public override TByte Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         => throw new NotSupportedException();
 
-    private byte GetByte(TByte value)
+    private static byte GetByte(TByte value)
         => Convert.ToByte(value);
 
     public override void Write(Utf8JsonWriter writer, TByte value, JsonSerializerOptions options)

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Serialization/SingleByteJsonConverter.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Serialization/SingleByteJsonConverter.cs
@@ -13,7 +13,7 @@ internal sealed class SingleByteJsonConverter<TByte> : JsonConverter<TByte>
         => throw new NotSupportedException();
 
     private static byte GetByte(TByte value)
-        => Convert.ToByte(value);
+        => Convert.ToByte(value, provider: null);
 
     public override void Write(Utf8JsonWriter writer, TByte value, JsonSerializerOptions options)
     {

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Serialization/SingleByteJsonConverterFactory.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Serialization/SingleByteJsonConverterFactory.cs
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
+#pragma warning disable CA1812
+
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite.Serialization/SingleUInt16JsonConverter.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite.Serialization/SingleUInt16JsonConverter.cs
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
+#pragma warning disable CA1812
+
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.Extensions.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.Extensions.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 
 namespace EchoDotNetLite
 {
+#pragma warning disable IDE0040
     partial class EchoClient
+#pragma warning restore IDE0040
     {
         /// <summary>
         /// インスタンスリスト通知の受信による更新を開始するときに発生するイベント。

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.OriginalAPI.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.OriginalAPI.cs
@@ -8,7 +8,9 @@ using System.Threading.Tasks;
 
 namespace EchoDotNetLite
 {
+#pragma warning disable IDE0040
     partial class EchoClient
+#pragma warning restore IDE0040
     {
         [Obsolete($"Use {nameof(Nodes)} instead.")]
         public ICollection<EchoNode> NodeList => Nodes;

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.OriginalAPI.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.OriginalAPI.cs
@@ -40,7 +40,7 @@ namespace EchoDotNetLite
         private static CancellationTokenSource CreateTimeoutCancellationTokenSource(int timeoutMilliseconds)
         {
             if (0 > timeoutMilliseconds)
-                throw new ArgumentOutOfRangeException("タイムアウト時間に負の値を指定することはできません。", nameof(timeoutMilliseconds));
+                throw new ArgumentOutOfRangeException(message: "タイムアウト時間に負の値を指定することはできません。", actualValue: timeoutMilliseconds, paramName: nameof(timeoutMilliseconds));
 
             if (timeoutMilliseconds == Timeout.Infinite)
                 return new CancellationTokenSource();

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.cs
@@ -1753,7 +1753,9 @@ namespace EchoDotNetLite
         /// <seealso href="https://echonet.jp/spec_v114_lite/">
         /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
         /// </seealso>
+#pragma warning disable IDE0060
         private async Task<bool> HandlePropertyValueNotificationRequestAsync((IPAddress address, Frame frame) request, EDATA1 edata, EchoNode sourceNode)
+#pragma warning restore IDE0060
         {
             if (edata.OPCList is null)
                 throw new InvalidOperationException($"{nameof(edata.OPCList)} is null");

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.cs
@@ -1205,7 +1205,7 @@ namespace EchoDotNetLite
                 sb.AppendLine("------");
                 foreach (var temp in device.Properties)
                 {
-                    sb.AppendFormat("\t{0}\r\n", temp.GetDebugString());
+                    sb.Append('\t').Append(temp.GetDebugString()).AppendLine();
                 }
                 sb.AppendLine("------");
                 _logger.LogTrace(sb.ToString());

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.cs
@@ -1226,6 +1226,7 @@ namespace EchoDotNetLite
         /// ECHONET Lite フレームの送信元を表す<see cref="IPAddress"/>と、受信したECHONET Lite フレームを表す<see cref="Frame"/>を保持します。
         /// </param>
         /// <exception cref="InvalidOperationException">電文形式 1（規定電文形式）を期待しましたが、<see cref="EDATA1"/>を取得できませんでした。</exception>
+#pragma warning disable CA1502 // TODO: reduce complexity
         private void HandleFrameReceived(object? sender, (IPAddress address, Frame frame) value)
         {
             if (value.frame.EHD1 != EHD1.ECHONETLite)
@@ -1336,6 +1337,7 @@ namespace EchoDotNetLite
                 }
             });
         }
+#pragma warning restore CA1502
 
         /// <summary>
         /// ECHONET Lite サービス「SetI:プロパティ値書き込み要求（応答不要）」(ESV <c>0x60</c>)を処理します。

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/Client.cs
@@ -33,7 +33,7 @@ namespace EchoDotNetLite
         /// ECHONET Lite フレームのリクエスト送信時の排他区間を定義するセマフォ。
         /// <see cref="_requestFrameBuffer"/>への書き込み、および<see cref="_echonetLiteHandler"/>による送信を排他制御するために使用する。
         /// </summary>
-        private readonly SemaphoreSlim _requestSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
+        private readonly SemaphoreSlim _requestSemaphore = new(initialCount: 1, maxCount: 1);
 
         /// <summary>
         /// <see cref="IEchonetLiteHandler.Received"/>イベントにてECHONET Lite フレームを受信した場合に発生するイベント。

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/FrameSerializer.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/FrameSerializer.cs
@@ -364,17 +364,36 @@ namespace EchoDotNetLite
             bool failIfEmpty
         )
         {
+            IEnumerable<PropertyRequest> opcListNonEnumerated;
+
+#if NET6_0_OR_GREATER
+            if (opcList.TryGetNonEnumeratedCount(out var countOfProps)) {
+              opcListNonEnumerated = opcList;
+            }
+            else {
+              var evaluatedOpcList = opcList.ToList();
+
+              countOfProps = evaluatedOpcList.Count;
+              opcListNonEnumerated = evaluatedOpcList;
+            }
+#else
+            var evaluatedOpcList = opcList.ToList();
+            var countOfProps = evaluatedOpcList.Count;
+
+            opcListNonEnumerated = evaluatedOpcList;
+#endif
+
             // ４．２．３ サービス内容に関する詳細シーケンス
             // OPC 処理プロパティ数(1B)
             // ４.２.３.４ プロパティ値書き込み読み出しサービス［0x6E,0x7E,0x5E］
             // OPCSet 処理プロパティ数(1B)
             // OPCGet 処理プロパティ数(1B)
-            if (failIfEmpty && !opcList.Any()) // XXX: expecting LINQ optimization
+            if (failIfEmpty && countOfProps == 0)
                 return false;
 
-            Write(buffer, (byte)opcList.Count()); // XXX: expecting LINQ optimization
+            Write(buffer, (byte)countOfProps);
 
-            foreach (var prp in opcList)
+            foreach (var prp in opcListNonEnumerated)
             {
                 // ECHONET Liteプロパティ(1B)
                 Write(buffer, prp.EPC);

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/FrameSerializer.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/FrameSerializer.cs
@@ -212,7 +212,7 @@ namespace EchoDotNetLite
                 // ECHONET Liteプロパティ(1B)
                 // EDTのバイト数(1B)
                 // プロパティ値データ(PDCで指定)
-                if (!TryReadEDATA1ProcessingTargetProperties(bytes, out var opcGetList, out var bytesReadForOPCGetList))
+                if (!TryReadEDATA1ProcessingTargetProperties(bytes, out var opcGetList, out _ /* var bytesReadForOPCGetList */))
                     return false;
 
                 edata = new
@@ -224,7 +224,7 @@ namespace EchoDotNetLite
                     opcGetList
                 );
 
-                bytes = bytes.Slice(bytesReadForOPCGetList);
+                // bytes = bytes.Slice(bytesReadForOPCGetList);
             }
             else
             {
@@ -232,10 +232,10 @@ namespace EchoDotNetLite
                 // ECHONET Liteプロパティ(1B)
                 // EDTのバイト数(1B)
                 // プロパティ値データ(PDCで指定)
-                if (!TryReadEDATA1ProcessingTargetProperties(bytes, out var opcList, out var bytesRead))
+                if (!TryReadEDATA1ProcessingTargetProperties(bytes, out var opcList, out _ /* var bytesRead */))
                     return false;
 
-                bytes = bytes.Slice(bytesRead);
+                // bytes = bytes.Slice(bytesRead);
 
                 edata = new
                 (

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/IEchonetLiteHandler.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/IEchonetLiteHandler.cs
@@ -2,9 +2,7 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
 using System;
-using System.Collections.Generic;
 using System.Net;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/PropertyContentSerializer.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/PropertyContentSerializer.cs
@@ -206,7 +206,7 @@ public static class PropertyContentSerializer
 
                 for (var j = 0; j < 8; j++)
                 {
-                    var upper = 0x80 + 0x10 * j;
+                    var upper = 0x80 + (0x10 * j);
                     var bitMask = 1 << j;
 
                     if ((propertyBits & bitMask) != 0)

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLite/PropertyContentSerializer.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLite/PropertyContentSerializer.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLiteLANBridge/UdpEchonetLiteHandler.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLiteLANBridge/UdpEchonetLiteHandler.cs
@@ -42,7 +42,7 @@ namespace EchoDotNetLiteLANBridge
                 {
                     while (true)
                     {
-                        var receivedResults = await receiveUdpClient.ReceiveAsync();
+                        var receivedResults = await receiveUdpClient.ReceiveAsync().ConfigureAwait(false);
                         if (selfAddresses.Contains(receivedResults.RemoteEndPoint.Address))
                         {
                             //ブロードキャストを自分で受信(無視)
@@ -109,9 +109,9 @@ namespace EchoDotNetLiteLANBridge
             };
             sendUdpClient.Connect(remote);
 #if NET6_0_OR_GREATER
-            await sendUdpClient.SendAsync(data, cancellationToken);
+            await sendUdpClient.SendAsync(data, cancellationToken).ConfigureAwait(false);
 #else
-            await sendUdpClient.SendAsync(data.ToArray(), data.Length);
+            await sendUdpClient.SendAsync(data.ToArray(), data.Length).ConfigureAwait(false);
 #endif
             sendUdpClient.Close();
         }

--- a/src/Smdn.Net.EchonetLite/EchoDotNetLiteLANBridge/UdpEchonetLiteHandler.cs
+++ b/src/Smdn.Net.EchonetLite/EchoDotNetLiteLANBridge/UdpEchonetLiteHandler.cs
@@ -2,14 +2,15 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
 using EchoDotNetLite;
-using EchoDotNetLite.Models;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+#if !NET5_0_OR_GREATER
 using System.Runtime.InteropServices;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.csproj
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.csproj
@@ -7,6 +7,8 @@ SPDX-License-Identifier: MIT
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
### Description
NuGetパッケージをリリースするにあたり、主にアセンブリ属性の指定を共通化する目的で`Smdn.MSBuild.ProjectAssets.Common`を導入する。
あわせて、このパッケージの導入により有効になるcode analysis/code styleの警告を修正する。

### Considerations
`EchoDotNetLite`とのAPI互換性をできるだけ維持するために、それを破壊する可能性のある警告は修正せず、無効化する。
今後API互換性の維持を継続しなくなった時点で、警告を再度有効化する。

また上記と同様の理由で、`Smdn.MSBuild.ProjectAssets.Library`の導入も現時点では見送る。
