### PR TITLE
オブジェクト詳細マスタのコレクション型をIReadOnlyDictionaryにする

### DIFF
--- a/src/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/EchonetObjectSpecification.cs
+++ b/src/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/EchonetObjectSpecification.cs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: MIT
 using System;
 using System.Collections.Generic;
-using System.Linq;
+#if SYSTEM_COLLECTIONS_OBJECTMODEL_READONLYDICTIONARY_EMPTY
+using System.Collections.ObjectModel;
+#endif
 
 namespace Smdn.Net.EchonetLite.Appendix
 {
@@ -12,6 +14,13 @@ namespace Smdn.Net.EchonetLite.Appendix
     /// </summary>
     public sealed class EchonetObjectSpecification
     {
+        private static readonly IReadOnlyDictionary<byte, EchonetPropertySpecification> EmptyPropertyDictionary
+#if SYSTEM_COLLECTIONS_OBJECTMODEL_READONLYDICTIONARY_EMPTY
+            = ReadOnlyDictionary<byte, EchonetPropertySpecification>.Empty;
+#else
+            = new Dictionary<byte, EchonetPropertySpecification>(capacity: 0);
+#endif
+
         /// <summary>
         /// 指定されたクラスグループコード・クラスコードをもつ、未知のECHONET Lite オブジェクトを作成します。
         /// </summary>
@@ -51,7 +60,47 @@ namespace Smdn.Net.EchonetLite.Appendix
             ) objectSpecification
         )
         {
-            (ClassGroup, Class, Properties) = objectSpecification;
+            (ClassGroup, Class, var properties) = objectSpecification;
+
+            if (properties.Count == 0) {
+                AllProperties = EmptyPropertyDictionary;
+                GetProperties = EmptyPropertyDictionary;
+                SetProperties = EmptyPropertyDictionary;
+                AnnoProperties = EmptyPropertyDictionary;
+            }
+            else {
+                AllProperties = ToDictionary(properties, predicate: null);
+                GetProperties = ToDictionary(properties, static p => p.CanGet);
+                SetProperties = ToDictionary(properties, static p => p.CanSet);
+                AnnoProperties = ToDictionary(properties, static p => p.CanAnnounceStatusChange);
+            }
+
+            // EchonetPropertySpecification.Codeをキーとするディクショナリに変換する
+            static IReadOnlyDictionary<byte, EchonetPropertySpecification> ToDictionary(
+                IReadOnlyList<EchonetPropertySpecification> specs,
+                Func<EchonetPropertySpecification, bool>? predicate
+            )
+            {
+              var keyedSpecs = new Dictionary<byte, EchonetPropertySpecification>(capacity: specs.Count);
+
+              foreach (var spec in specs) {
+                  if (predicate is not null && !predicate(spec))
+                      continue;
+
+                  // ここで、specsにはスーパークラスと派生クラスの両方のプロパティが含まれる場合がある。
+                  // マスタからの読み込み順の動作により、specsにはスーパークラスのプロパティのほうが
+                  // 先頭側に格納されている。
+                  // したがって、specs内に同じキーのプロパティが存在する場合は後に列挙されるプロパティを
+                  // 上書きすることにより、派生クラスのプロパティを保持する。
+                  keyedSpecs[spec.Code] = spec;
+              }
+
+#if SYSTEM_COLLECTIONS_GENERIC_DICTIONARY_TRIMEXCESS
+              keyedSpecs.TrimExcess(); // reduce capacity
+#endif
+
+              return keyedSpecs;
+            }
         }
 
         /// <summary>
@@ -68,28 +117,21 @@ namespace Smdn.Net.EchonetLite.Appendix
         /// <summary>
         /// 仕様上定義済みのプロパティの一覧
         /// </summary>
-        internal IReadOnlyList<EchonetPropertySpecification> Properties { get; }
+        internal IReadOnlyDictionary<byte, EchonetPropertySpecification> AllProperties { get; }
 
         /// <summary>
         /// 仕様上定義済みのGETプロパティの一覧
         /// </summary>
-        public IEnumerable<EchonetPropertySpecification> GetProperties
-        {
-            get { return Properties.Where(static p => p.CanGet); }
-        }
+        public IReadOnlyDictionary<byte, EchonetPropertySpecification> GetProperties { get; }
+
         /// <summary>
         /// 仕様上定義済みのSETプロパティの一覧
         /// </summary>
-        public IEnumerable<EchonetPropertySpecification> SetProperties
-        {
-            get { return Properties.Where(static p => p.CanSet); }
-        }
+        public IReadOnlyDictionary<byte, EchonetPropertySpecification> SetProperties { get; }
+
         /// <summary>
         /// 仕様上定義済みのANNOプロパティの一覧
         /// </summary>
-        public IEnumerable<EchonetPropertySpecification> AnnoProperties
-        {
-            get { return Properties.Where(static p => p.CanAnnounceStatusChange); }
-        }
+        public IReadOnlyDictionary<byte, EchonetPropertySpecification> AnnoProperties { get; }
     }
 }

--- a/src/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/EchonetObjectSpecification.cs
+++ b/src/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/EchonetObjectSpecification.cs
@@ -117,7 +117,7 @@ namespace Smdn.Net.EchonetLite.Appendix
         /// <summary>
         /// 仕様上定義済みのプロパティの一覧
         /// </summary>
-        internal IReadOnlyDictionary<byte, EchonetPropertySpecification> AllProperties { get; }
+        public IReadOnlyDictionary<byte, EchonetPropertySpecification> AllProperties { get; }
 
         /// <summary>
         /// 仕様上定義済みのGETプロパティの一覧

--- a/src/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/SpecificationMaster.cs
+++ b/src/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/SpecificationMaster.cs
@@ -131,8 +131,6 @@ namespace Smdn.Net.EchonetLite.Appendix
                 }
             }
 
-            properties.TrimExcess(); // reduce capacity
-
             return (
                 classGroupSpec,
                 classSpec,

--- a/src/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite/DeviceClasses.cs
+++ b/src/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite/DeviceClasses.cs
@@ -96,14 +96,13 @@ namespace Smdn.Net.EchonetLite
         )
         {
             if (TryLookupClass(classGroupCode, classCode, includeProfiles, out var obj)) {
-                var prop = obj
+                var allProps = obj
 #if !NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES
-                  !
+                    !
 #endif
-                  .Properties
-                  .FirstOrDefault(p => p.Code == propertyCode); // TODO: use IReadOnlyDictionary.TryGetValue(TKey, TValue)
+                    .AllProperties;
 
-                if (prop is not null)
+                if (allProps.TryGetValue(propertyCode, out var prop))
                     return prop;
             }
 

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
@@ -43,15 +43,15 @@ namespace Smdn.Net.EchonetLite
 
             properties = new();
 
-            foreach (var prop in classObject.GetProperties)
+            foreach (var prop in classObject.GetProperties.Values)
             {
                 properties.Add(new(prop));
             }
-            foreach (var prop in classObject.SetProperties)
+            foreach (var prop in classObject.SetProperties.Values)
             {
                 properties.Add(new(prop));
             }
-            foreach (var prop in classObject.AnnoProperties)
+            foreach (var prop in classObject.AnnoProperties.Values)
             {
                 properties.Add(new(prop));
             }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
@@ -43,15 +43,7 @@ namespace Smdn.Net.EchonetLite
 
             properties = new();
 
-            foreach (var prop in classObject.GetProperties.Values)
-            {
-                properties.Add(new(prop));
-            }
-            foreach (var prop in classObject.SetProperties.Values)
-            {
-                properties.Add(new(prop));
-            }
-            foreach (var prop in classObject.AnnoProperties.Values)
+            foreach (var prop in classObject.AllProperties.Values)
             {
                 properties.Add(new(prop));
             }

--- a/tests/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/EchonetObjectSpecification.cs
+++ b/tests/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/EchonetObjectSpecification.cs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Reflection;
+
+using NUnit.Framework;
+
+namespace Smdn.Net.EchonetLite.Appendix;
+
+[TestFixture]
+public class EchonetObjectSpecificationTests {
+  [Test]
+  public void GetProperties_NodeProfile()
+  {
+    Assert.That(Profiles.NodeProfile.GetProperties.Count, Is.EqualTo(18));
+  }
+
+  // 0x0EF0 ノードプロファイル
+  [TestCase(0x80, true)]
+  [TestCase(0x82, true)]
+  [TestCase(0x83, true)]
+  [TestCase(0x89, true)]
+  [TestCase(0xBF, true)]
+  [TestCase(0xD3, true)]
+  [TestCase(0xD4, true)]
+  [TestCase(0xD6, true)]
+  [TestCase(0xD7, true)]
+  // プロファイルオブジェクトスーパークラス
+  [TestCase(0x88, true)]
+  [TestCase(0x8A, true)]
+  [TestCase(0x8B, true)]
+  [TestCase(0x8C, true)]
+  [TestCase(0x8D, true)]
+  [TestCase(0x8E, true)]
+  [TestCase(0x8F, false)]
+  [TestCase(0x9D, true)]
+  [TestCase(0x9E, true)]
+  [TestCase(0x9F, true)]
+  // not defined
+  [TestCase(0x00, false)]
+  [TestCase(0xFF, false)]
+  public void GetProperties_NodeProfile_ByEPC(byte epc, bool expected)
+  {
+    Assert.That(Profiles.NodeProfile.GetProperties.TryGetValue(epc, out var p), Is.EqualTo(expected));
+
+    if (expected)
+      Assert.That(p, Is.Not.Null);
+  }
+
+  [Test]
+  public void SetProperties_NodeProfile()
+  {
+    Assert.That(Profiles.NodeProfile.SetProperties.Count, Is.EqualTo(2));
+  }
+
+  // 0x0EF0 ノードプロファイル
+  [TestCase(0x80, true)]
+  [TestCase(0xBF, true)]
+  // プロファイルオブジェクトスーパークラス
+  [TestCase(0x8F, false)]
+  // not defined
+  [TestCase(0x00, false)]
+  [TestCase(0xFF, false)]
+  public void SetProperties_NodeProfile_ByEPC(byte epc, bool expected)
+  {
+    Assert.That(Profiles.NodeProfile.SetProperties.TryGetValue(epc, out var p), Is.EqualTo(expected));
+
+    if (expected)
+      Assert.That(p, Is.Not.Null);
+  }
+
+  [Test]
+  public void AnnoProperties_NodeProfile()
+  {
+    Assert.That(Profiles.NodeProfile.AnnoProperties.Count, Is.EqualTo(2));
+  }
+
+  // 0x0EF0 ノードプロファイル
+  [TestCase(0x80, true)]
+  [TestCase(0xD5, true)]
+  [TestCase(0xD6, false)]
+  // プロファイルオブジェクトスーパークラス
+  [TestCase(0x8F, false)]
+  // not defined
+  [TestCase(0x00, false)]
+  [TestCase(0xFF, false)]
+  public void AnnoProperties_NodeProfile_ByEPC(byte epc, bool expected)
+  {
+    Assert.That(Profiles.NodeProfile.AnnoProperties.TryGetValue(epc, out var p), Is.EqualTo(expected));
+
+    if (expected)
+      Assert.That(p, Is.Not.Null);
+  }
+}

--- a/tests/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/EchonetObjectSpecification.cs
+++ b/tests/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/EchonetObjectSpecification.cs
@@ -13,6 +13,48 @@ namespace Smdn.Net.EchonetLite.Appendix;
 [TestFixture]
 public class EchonetObjectSpecificationTests {
   [Test]
+  public void AllProperties_NodeProfile()
+  {
+    Assert.That(Profiles.NodeProfile.AllProperties.Count, Is.EqualTo(19));
+
+    Assert.That(Profiles.NodeProfile.GetProperties.All(static p => Profiles.NodeProfile.AllProperties.Contains(p)), Is.True);
+    Assert.That(Profiles.NodeProfile.SetProperties.All(static p => Profiles.NodeProfile.AllProperties.Contains(p)), Is.True);
+    Assert.That(Profiles.NodeProfile.AnnoProperties.All(static p => Profiles.NodeProfile.AllProperties.Contains(p)), Is.True);
+  }
+
+  // 0x0EF0 ノードプロファイル
+  [TestCase(0x80, true)]
+  [TestCase(0x82, true)]
+  [TestCase(0x83, true)]
+  [TestCase(0x89, true)]
+  [TestCase(0xBF, true)]
+  [TestCase(0xD3, true)]
+  [TestCase(0xD4, true)]
+  [TestCase(0xD5, true)]
+  [TestCase(0xD6, true)]
+  [TestCase(0xD7, true)]
+  // プロファイルオブジェクトスーパークラス
+  [TestCase(0x88, true)]
+  [TestCase(0x8A, true)]
+  [TestCase(0x8B, true)]
+  [TestCase(0x8C, true)]
+  [TestCase(0x8D, true)]
+  [TestCase(0x8E, true)]
+  [TestCase(0x9D, true)]
+  [TestCase(0x9E, true)]
+  [TestCase(0x9F, true)]
+  // not defined
+  [TestCase(0x00, false)]
+  [TestCase(0xFF, false)]
+  public void AllProperties_NodeProfile_ByEPC(byte epc, bool expected)
+  {
+    Assert.That(Profiles.NodeProfile.AllProperties.TryGetValue(epc, out var p), Is.EqualTo(expected));
+
+    if (expected)
+      Assert.That(p, Is.Not.Null);
+  }
+
+  [Test]
   public void GetProperties_NodeProfile()
   {
     Assert.That(Profiles.NodeProfile.GetProperties.Count, Is.EqualTo(18));
@@ -26,6 +68,7 @@ public class EchonetObjectSpecificationTests {
   [TestCase(0xBF, true)]
   [TestCase(0xD3, true)]
   [TestCase(0xD4, true)]
+  [TestCase(0xD5, false)]
   [TestCase(0xD6, true)]
   [TestCase(0xD7, true)]
   // プロファイルオブジェクトスーパークラス
@@ -59,6 +102,7 @@ public class EchonetObjectSpecificationTests {
   // 0x0EF0 ノードプロファイル
   [TestCase(0x80, true)]
   [TestCase(0xBF, true)]
+  [TestCase(0xD5, false)]
   // プロファイルオブジェクトスーパークラス
   [TestCase(0x8F, false)]
   // not defined

--- a/tests/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/EchonetPropertySpecification.cs
+++ b/tests/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite.Appendix/EchonetPropertySpecification.cs
@@ -167,25 +167,21 @@ public class EchoPropertyTests {
   {
     var obj = DeviceClasses.住宅設備関連機器.低圧スマート電力量メータ;
 
-    var epc8E = obj.GetProperties.First(static prop => prop.Code == 0x8E); // 製造年月日 Unit: ""
+    Assert.That(obj.GetProperties.TryGetValue(0x8E, out var epc8E), Is.True); // 製造年月日 Unit: ""
+    Assert.That(epc8E!.Unit, Is.Null, "EPC 8E");
+    Assert.That(epc8E!.HasUnit, Is.False, "EPC 8E");
 
-    Assert.That(epc8E.Unit, Is.Null, "EPC 8E");
-    Assert.That(epc8E.HasUnit, Is.False, "EPC 8E");
+    Assert.That(obj.GetProperties.TryGetValue(0xD3, out var epcD3), Is.True); // 係数 Unit: ""
+    Assert.That(epcD3!.Unit, Is.Null, "EPC D3");
+    Assert.That(epcD3!.HasUnit, Is.False, "EPC D3");
 
-    var epcD3 = obj.GetProperties.First(static prop => prop.Code == 0xD3); // 係数 Unit: ""
+    Assert.That(obj.GetProperties.TryGetValue(0xE1, out var epcE1), Is.True); // 積算電力量単位 （正方向、逆方向計測値） Unit: "－"
+    Assert.That(epcE1!.Unit, Is.Null, "EPC E1");
+    Assert.That(epcE1!.HasUnit, Is.False, "EPC E1");
 
-    Assert.That(epcD3.Unit, Is.Null, "EPC D3");
-    Assert.That(epcD3.HasUnit, Is.False, "EPC D3");
-
-    var epcE1 = obj.GetProperties.First(static prop => prop.Code == 0xE1); // 積算電力量単位 （正方向、逆方向計測値） Unit: "－"
-
-    Assert.That(epcE1.Unit, Is.Null, "EPC E1");
-    Assert.That(epcE1.HasUnit, Is.False, "EPC E1");
-
-    var epcE7 = obj.GetProperties.First(static prop => prop.Code == 0xE7); // 瞬時電力計測値 Unit: "W"
-
-    Assert.That(epcE7.Unit, Is.EqualTo("W"), "EPC E7");
-    Assert.That(epcE7.HasUnit, Is.True, "EPC E7");
+    Assert.That(obj.GetProperties.TryGetValue(0xE7, out var epcE7), Is.True); // 瞬時電力計測値 Unit: "W"
+    Assert.That(epcE7!.Unit, Is.EqualTo("W"), "EPC E7");
+    Assert.That(epcE7!.HasUnit, Is.True, "EPC E7");
   }
 
   private static System.Collections.IEnumerable YieldTestCases_Deserialize()

--- a/tests/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite/DeviceClasses.cs
+++ b/tests/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite/DeviceClasses.cs
@@ -63,14 +63,13 @@ public class DeviceClassesTests {
   [TestCaseSource(nameof(YieldTestCases_機器オブジェクトスーパークラスJson))]
   public void 機器オブジェクトスーパークラスJson(EchonetObjectSpecification obj)
   {
-    var epc80 = obj.GetProperties.FirstOrDefault(static prop => prop.Name == "動作状態");
+    var epc80 = obj.GetProperties.Values.FirstOrDefault(static prop => prop.Name == "動作状態");
 
     Assert.That(epc80, Is.Not.Null);
     Assert.That(epc80!.Code, Is.EqualTo(0x80), nameof(epc80.Code));
     Assert.That(epc80.DataType, Is.EqualTo("unsigned char"), nameof(epc80.DataType));
 
-    var epc9D = obj.GetProperties.FirstOrDefault(static prop => prop.Code == 0x9D);
-
+    Assert.That(obj.GetProperties.TryGetValue(0x9D, out var epc9D), Is.True);
     Assert.That(epc9D, Is.Not.Null);
     Assert.That(epc9D!.Name, Is.EqualTo("状変アナウンスプロパティマップ"), nameof(epc9D.Code));
     Assert.That(epc9D.DataType, Is.EqualTo("unsigned char×(MAX17)"), nameof(epc9D.DataType));
@@ -81,16 +80,14 @@ public class DeviceClassesTests {
   {
     var obj = DeviceClasses.住宅設備関連機器.低圧スマート電力量メータ;
 
-    var epcE0 = obj.GetProperties.FirstOrDefault(static prop => prop.Code == 0xE0);
-
+    Assert.That(obj.GetProperties.TryGetValue(0xE0, out var epcE0), Is.True);
     Assert.That(epcE0, Is.Not.Null);
     Assert.That(epcE0!.Code, Is.EqualTo(0xE0), nameof(epcE0.Code));
     Assert.That(epcE0.Name, Is.EqualTo("積算電力量計測値 (正方向計測値)"), nameof(epcE0.Name));
     Assert.That(epcE0.DataType, Is.EqualTo("unsigned long"), nameof(epcE0.DataType));
     Assert.That(epcE0.Unit, Is.EqualTo("kWh"), nameof(epcE0.Unit));
 
-    var epcE7 = obj.GetProperties.FirstOrDefault(static prop => prop.Code == 0xE7);
-
+    Assert.That(obj.GetProperties.TryGetValue(0xE7, out var epcE7), Is.True);
     Assert.That(epcE7, Is.Not.Null);
     Assert.That(epcE7!.Code, Is.EqualTo(0xE7), nameof(epcE7.Code));
     Assert.That(epcE7!.Name, Is.EqualTo("瞬時電力計測値"), nameof(epcE7.Name));
@@ -103,8 +100,7 @@ public class DeviceClassesTests {
   {
     var obj = DeviceClasses.ＡＶ関連機器.テレビ;
 
-    var epc80 = obj.GetProperties.LastOrDefault(static prop => prop.Code == 0x80); // overrides properties from super class
-
+    Assert.That(obj.GetProperties.TryGetValue(0x80, out var epc80), Is.True); // overrides properties from super class
     Assert.That(epc80, Is.Not.Null);
     Assert.That(epc80!.Code, Is.EqualTo(0x80), nameof(epc80.Code));
     Assert.That(epc80.Name, Is.EqualTo("動作状態"), nameof(epc80.Name));
@@ -115,15 +111,13 @@ public class DeviceClassesTests {
       nameof(epc80.OptionRequired)
     );
 
-    var epcB0 = obj.GetProperties.FirstOrDefault(static prop => prop.Code == 0xB0);
-
+    Assert.That(obj.GetProperties.TryGetValue(0xB0, out var epcB0), Is.True);
     Assert.That(epcB0, Is.Not.Null);
     Assert.That(epcB0!.Code, Is.EqualTo(0xB0), nameof(epcB0.Code));
     Assert.That(epcB0.Name, Is.EqualTo("表示制御設定"), nameof(epcB0.Name));
     Assert.That(epcB0.OptionRequired ?? Enumerable.Empty<ApplicationServiceName>(), Is.Empty, nameof(epcB0.OptionRequired));
 
-    var epcB1 = obj.GetProperties.FirstOrDefault(static prop => prop.Code == 0xB1);
-
+    Assert.That(obj.GetProperties.TryGetValue(0xB1, out var epcB1), Is.True);
     Assert.That(epcB1, Is.Not.Null);
     Assert.That(epcB1!.Code, Is.EqualTo(0xB1), nameof(epcB1.Code));
     Assert.That(epcB1.Name, Is.EqualTo("文字列設定受付可能状態"), nameof(epcB1.Name));

--- a/tests/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite/Profiles.cs
+++ b/tests/Smdn.Net.EchonetLite.Appendix/Smdn.Net.EchonetLite/Profiles.cs
@@ -32,19 +32,21 @@ public class ProfilesTests {
     Assert.That(c.Name, Is.EqualTo("ノードプロファイル"), nameof(EchonetClassSpecification.Name));
 
     Assert.That(
-      p.GetProperties.First(static prop => prop.Name == "状変アナウンスプロパティマップ").Code,
+      p.GetProperties.Values.First(static prop => prop.Name == "状変アナウンスプロパティマップ").Code,
       Is.EqualTo(0x9D),
       "状変アナウンスプロパティマップ"
     );
 
+    Assert.That(p.GetProperties.TryGetValue(0x9E, out var epc9E), Is.True);
     Assert.That(
-      p.GetProperties.First(static prop => prop.Code == 0x9E).Name,
+      epc9E!.Name,
       Is.EqualTo("Set プロパティマップ"),
       "Set プロパティマップ"
     );
 
+    Assert.That(p.GetProperties.TryGetValue(0x9F, out var epc9F), Is.True);
     Assert.That(
-      p.GetProperties.First(static prop => prop.Code == 0x9F).Name,
+      epc9F!.Name,
       Is.EqualTo("Get プロパティマップ"),
       "Get プロパティマップ"
     );
@@ -53,14 +55,13 @@ public class ProfilesTests {
   [Test]
   public void プロファイルオブジェクトスーパークラスJson()
   {
-    var epc88 = Profiles.NodeProfile.GetProperties.FirstOrDefault(static prop => prop.Name == "異常発生状態");
+    var epc88 = Profiles.NodeProfile.GetProperties.Values.FirstOrDefault(static prop => prop.Name == "異常発生状態");
 
     Assert.That(epc88, Is.Not.Null);
     Assert.That(epc88!.Code, Is.EqualTo(0x88), nameof(epc88.Code));
     Assert.That(epc88.DataType, Is.EqualTo("unsigned char"), nameof(epc88.DataType));
 
-    var epc9D = Profiles.NodeProfile.GetProperties.FirstOrDefault(static prop => prop.Code == 0x9D);
-
+    Assert.That(Profiles.NodeProfile.GetProperties.TryGetValue(0x9D, out var epc9D), Is.True);
     Assert.That(epc9D, Is.Not.Null);
     Assert.That(epc9D!.Name, Is.EqualTo("状変アナウンスプロパティマップ"), nameof(epc9D.Code));
     Assert.That(epc9D.DataType, Is.EqualTo("unsigned char×(MAX17)"), nameof(epc9D.DataType));
@@ -69,8 +70,7 @@ public class ProfilesTests {
   [Test]
   public void MasterData_プロファイル_ノードプロファイルJson()
   {
-    var epc82 = Profiles.NodeProfile.GetProperties.FirstOrDefault(static prop => prop.Code == 0x82);
-
+    Assert.That(Profiles.NodeProfile.GetProperties.TryGetValue(0x82, out var epc82), Is.True);
     Assert.That(epc82, Is.Not.Null);
     Assert.That(epc82!.Code, Is.EqualTo(0x82), nameof(epc82.Code));
     Assert.That(epc82.Name, Is.EqualTo("Version 情報"), nameof(epc82.Name));
@@ -78,8 +78,7 @@ public class ProfilesTests {
     Assert.That(epc82.Unit, Is.Null, nameof(epc82.Unit));
     Assert.That(epc82.HasUnit, Is.False, nameof(epc82.Unit));
 
-    var epcD3 = Profiles.NodeProfile.GetProperties.FirstOrDefault(static prop => prop.Code == 0xD3);
-
+    Assert.That(Profiles.NodeProfile.GetProperties.TryGetValue(0xD3, out var epcD3), Is.True);
     Assert.That(epcD3, Is.Not.Null);
     Assert.That(epcD3!.Code, Is.EqualTo(0xD3), nameof(epcD3.Code));
     Assert.That(epcD3!.Name, Is.EqualTo("自ノードインスタンス数"), nameof(epcD3.Name));


### PR DESCRIPTION
### Description
`Smdn.Net.EchonetLite.Appendix`の以下のプロパティを、各コード(`byte`)をキーとするIReadOnlyDictionaryにする。
これにより、コードからオブジェクト・プロパティの詳細をルックアップする処理を効率化する。

- `SpecificationMaster.Profiles`
- `SpecificationMaster.DeviceClasses`
- `EchonetObjectSpecification.AllProperties`
- `EchonetObjectSpecification.GetProperties`
- `EchonetObjectSpecification.SetProperties`
- `EchonetObjectSpecification.AnnoProperties`

### Considerations
`Smdn.Net.EchonetLite.EchonetObject`も同様の改善が可能だが、`ObservableDictionery`に相当する型が必要となるため、現時点では保留。
