### PR TITLE
Release main/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net6.0.apilist.cs
@@ -1,0 +1,101 @@
+// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1)
+//   Name: Smdn.Net.EchonetLite.RouteB.SkStackIP
+//   AssemblyVersion: 2.0.0.0
+//   InformationalVersion: 2.0.0-preview1+93509882219e05b5d6a8c897a8bdfee251761d59
+//   TargetFramework: .NETCoreApp,Version=v6.0
+//   Configuration: Release
+//   Referenced assemblies:
+//     Microsoft.Extensions.DependencyInjection, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.Logging.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
+//     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.SkStackIP, Version=1.0.0.0, Culture=neutral
+//     System.ComponentModel, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.ComponentModel.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Memory, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     System.Net.NetworkInformation, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Net.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Runtime, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Threading, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+#nullable enable annotations
+
+using System;
+using System.Buffers;
+using System.ComponentModel;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Smdn.Net.EchonetLite.RouteB.Credentials;
+using Smdn.Net.EchonetLite.RouteB.Transport;
+using Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP;
+using Smdn.Net.SkStackIP;
+
+namespace Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP {
+  public interface ISkStackRouteBEchonetLiteHandlerFactory : IRouteBEchonetLiteHandlerFactory {
+    Action<SkStackRouteBSessionConfiguration>? ConfigureRouteBSessionConfiguration { get; set; }
+  }
+
+  public enum SkStackRouteBTransportProtocol : int {
+    Tcp = 0,
+    Udp = 1,
+  }
+
+  public abstract class SkStackRouteBEchonetLiteHandler : RouteBEchonetLiteHandler {
+    public static readonly string ResiliencePipelineKeyForSend = "SkStackRouteBEchonetLiteHandler.resiliencePipelineSend";
+
+    public override IPAddress? LocalAddress { get; }
+    public override IPAddress? PeerAddress { get; }
+    public override ISynchronizeInvoke? SynchronizingObject { get; set; }
+
+    protected override ValueTask ConnectAsyncCore(IRouteBCredential credential, CancellationToken cancellationToken) {}
+    protected override async ValueTask DisconnectAsyncCore(CancellationToken cancellationToken) {}
+    protected override void Dispose(bool disposing) {}
+    protected override async ValueTask DisposeAsyncCore() {}
+    protected override ValueTask<IPAddress> ReceiveAsyncCore(IBufferWriter<byte> buffer, CancellationToken cancellationToken) {}
+    protected override ValueTask SendAsyncCore(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) {}
+    protected override ValueTask SendToAsyncCore(IPAddress remoteAddress, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) {}
+    [MemberNotNull("client")]
+    protected override void ThrowIfDisposed() {}
+  }
+
+  public static class SkStackRouteBEchonetLiteHandlerBuilderExtensions {
+    public static ISkStackRouteBEchonetLiteHandlerFactory ConfigureSession(this ISkStackRouteBEchonetLiteHandlerFactory factory, Action<SkStackRouteBSessionConfiguration> configureRouteBSessionConfiguration) {}
+  }
+
+  public abstract class SkStackRouteBEchonetLiteHandlerFactory : ISkStackRouteBEchonetLiteHandlerFactory {
+    protected SkStackRouteBEchonetLiteHandlerFactory(IServiceCollection services) {}
+
+    public Action<SkStackRouteBSessionConfiguration>? ConfigureRouteBSessionConfiguration { get; set; }
+    protected abstract SkStackRouteBTransportProtocol TransportProtocol { get; }
+
+    public virtual async ValueTask<RouteBEchonetLiteHandler> CreateAsync(CancellationToken cancellationToken) {}
+    protected abstract ValueTask<SkStackClient> CreateClientAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken);
+  }
+
+  public sealed class SkStackRouteBSessionConfiguration : ICloneable {
+    public SkStackRouteBSessionConfiguration() {}
+
+    public SkStackActiveScanOptions? ActiveScanOptions { get; set; }
+    public SkStackChannel? Channel { get; set; }
+    public IPAddress? PaaAddress { get; set; }
+    public PhysicalAddress? PaaMacAddress { get; set; }
+    public int? PanId { get; set; }
+
+    public SkStackRouteBSessionConfiguration Clone() {}
+    object ICloneable.Clone() {}
+  }
+
+  public sealed class SkStackRouteBTcpEchonetLiteHandler : SkStackRouteBEchonetLiteHandler {
+    public SkStackRouteBTcpEchonetLiteHandler(SkStackClient client, SkStackRouteBSessionConfiguration sessionConfiguration, bool shouldDisposeClient = false, IServiceProvider? serviceProvider = null) {}
+  }
+
+  public sealed class SkStackRouteBUdpEchonetLiteHandler : SkStackRouteBEchonetLiteHandler {
+    public SkStackRouteBUdpEchonetLiteHandler(SkStackClient client, SkStackRouteBSessionConfiguration sessionConfiguration, bool shouldDisposeClient = false, IServiceProvider? serviceProvider = null) {}
+  }
+}
+// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.4.1.0.
+// Smdn.Reflection.ReverseGenerating.ListApi.Core v1.3.1.0 (https://github.com/smdn/Smdn.Reflection.ReverseGenerating)

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net8.0.apilist.cs
@@ -1,0 +1,101 @@
+// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1)
+//   Name: Smdn.Net.EchonetLite.RouteB.SkStackIP
+//   AssemblyVersion: 2.0.0.0
+//   InformationalVersion: 2.0.0-preview1+93509882219e05b5d6a8c897a8bdfee251761d59
+//   TargetFramework: .NETCoreApp,Version=v8.0
+//   Configuration: Release
+//   Referenced assemblies:
+//     Microsoft.Extensions.DependencyInjection, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.Logging.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
+//     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.SkStackIP, Version=1.0.0.0, Culture=neutral
+//     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.ComponentModel.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Memory, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     System.Net.NetworkInformation, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Net.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Threading, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+#nullable enable annotations
+
+using System;
+using System.Buffers;
+using System.ComponentModel;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Smdn.Net.EchonetLite.RouteB.Credentials;
+using Smdn.Net.EchonetLite.RouteB.Transport;
+using Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP;
+using Smdn.Net.SkStackIP;
+
+namespace Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP {
+  public interface ISkStackRouteBEchonetLiteHandlerFactory : IRouteBEchonetLiteHandlerFactory {
+    Action<SkStackRouteBSessionConfiguration>? ConfigureRouteBSessionConfiguration { get; set; }
+  }
+
+  public enum SkStackRouteBTransportProtocol : int {
+    Tcp = 0,
+    Udp = 1,
+  }
+
+  public abstract class SkStackRouteBEchonetLiteHandler : RouteBEchonetLiteHandler {
+    public static readonly string ResiliencePipelineKeyForSend = "SkStackRouteBEchonetLiteHandler.resiliencePipelineSend";
+
+    public override IPAddress? LocalAddress { get; }
+    public override IPAddress? PeerAddress { get; }
+    public override ISynchronizeInvoke? SynchronizingObject { get; set; }
+
+    protected override ValueTask ConnectAsyncCore(IRouteBCredential credential, CancellationToken cancellationToken) {}
+    protected override async ValueTask DisconnectAsyncCore(CancellationToken cancellationToken) {}
+    protected override void Dispose(bool disposing) {}
+    protected override async ValueTask DisposeAsyncCore() {}
+    protected override ValueTask<IPAddress> ReceiveAsyncCore(IBufferWriter<byte> buffer, CancellationToken cancellationToken) {}
+    protected override ValueTask SendAsyncCore(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) {}
+    protected override ValueTask SendToAsyncCore(IPAddress remoteAddress, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) {}
+    [MemberNotNull("client")]
+    protected override void ThrowIfDisposed() {}
+  }
+
+  public static class SkStackRouteBEchonetLiteHandlerBuilderExtensions {
+    public static ISkStackRouteBEchonetLiteHandlerFactory ConfigureSession(this ISkStackRouteBEchonetLiteHandlerFactory factory, Action<SkStackRouteBSessionConfiguration> configureRouteBSessionConfiguration) {}
+  }
+
+  public abstract class SkStackRouteBEchonetLiteHandlerFactory : ISkStackRouteBEchonetLiteHandlerFactory {
+    protected SkStackRouteBEchonetLiteHandlerFactory(IServiceCollection services) {}
+
+    public Action<SkStackRouteBSessionConfiguration>? ConfigureRouteBSessionConfiguration { get; set; }
+    protected abstract SkStackRouteBTransportProtocol TransportProtocol { get; }
+
+    public virtual async ValueTask<RouteBEchonetLiteHandler> CreateAsync(CancellationToken cancellationToken) {}
+    protected abstract ValueTask<SkStackClient> CreateClientAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken);
+  }
+
+  public sealed class SkStackRouteBSessionConfiguration : ICloneable {
+    public SkStackRouteBSessionConfiguration() {}
+
+    public SkStackActiveScanOptions? ActiveScanOptions { get; set; }
+    public SkStackChannel? Channel { get; set; }
+    public IPAddress? PaaAddress { get; set; }
+    public PhysicalAddress? PaaMacAddress { get; set; }
+    public int? PanId { get; set; }
+
+    public SkStackRouteBSessionConfiguration Clone() {}
+    object ICloneable.Clone() {}
+  }
+
+  public sealed class SkStackRouteBTcpEchonetLiteHandler : SkStackRouteBEchonetLiteHandler {
+    public SkStackRouteBTcpEchonetLiteHandler(SkStackClient client, SkStackRouteBSessionConfiguration sessionConfiguration, bool shouldDisposeClient = false, IServiceProvider? serviceProvider = null) {}
+  }
+
+  public sealed class SkStackRouteBUdpEchonetLiteHandler : SkStackRouteBEchonetLiteHandler {
+    public SkStackRouteBUdpEchonetLiteHandler(SkStackClient client, SkStackRouteBSessionConfiguration sessionConfiguration, bool shouldDisposeClient = false, IServiceProvider? serviceProvider = null) {}
+  }
+}
+// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.4.1.0.
+// Smdn.Reflection.ReverseGenerating.ListApi.Core v1.3.1.0 (https://github.com/smdn/Smdn.Reflection.ReverseGenerating)

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-netstandard2.1.apilist.cs
@@ -1,0 +1,94 @@
+// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1)
+//   Name: Smdn.Net.EchonetLite.RouteB.SkStackIP
+//   AssemblyVersion: 2.0.0.0
+//   InformationalVersion: 2.0.0-preview1+93509882219e05b5d6a8c897a8bdfee251761d59
+//   TargetFramework: .NETStandard,Version=v2.1
+//   Configuration: Release
+//   Referenced assemblies:
+//     Microsoft.Extensions.DependencyInjection, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.Logging.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
+//     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.SkStackIP, Version=1.0.0.0, Culture=neutral
+//     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+#nullable enable annotations
+
+using System;
+using System.Buffers;
+using System.ComponentModel;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Smdn.Net.EchonetLite.RouteB.Credentials;
+using Smdn.Net.EchonetLite.RouteB.Transport;
+using Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP;
+using Smdn.Net.SkStackIP;
+
+namespace Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP {
+  public interface ISkStackRouteBEchonetLiteHandlerFactory : IRouteBEchonetLiteHandlerFactory {
+    Action<SkStackRouteBSessionConfiguration>? ConfigureRouteBSessionConfiguration { get; set; }
+  }
+
+  public enum SkStackRouteBTransportProtocol : int {
+    Tcp = 0,
+    Udp = 1,
+  }
+
+  public abstract class SkStackRouteBEchonetLiteHandler : RouteBEchonetLiteHandler {
+    public static readonly string ResiliencePipelineKeyForSend = "SkStackRouteBEchonetLiteHandler.resiliencePipelineSend";
+
+    public override IPAddress? LocalAddress { get; }
+    public override IPAddress? PeerAddress { get; }
+    public override ISynchronizeInvoke? SynchronizingObject { get; set; }
+
+    protected override ValueTask ConnectAsyncCore(IRouteBCredential credential, CancellationToken cancellationToken) {}
+    protected override async ValueTask DisconnectAsyncCore(CancellationToken cancellationToken) {}
+    protected override void Dispose(bool disposing) {}
+    protected override async ValueTask DisposeAsyncCore() {}
+    protected override ValueTask<IPAddress> ReceiveAsyncCore(IBufferWriter<byte> buffer, CancellationToken cancellationToken) {}
+    protected override ValueTask SendAsyncCore(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) {}
+    protected override ValueTask SendToAsyncCore(IPAddress remoteAddress, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) {}
+    protected override void ThrowIfDisposed() {}
+  }
+
+  public static class SkStackRouteBEchonetLiteHandlerBuilderExtensions {
+    public static ISkStackRouteBEchonetLiteHandlerFactory ConfigureSession(this ISkStackRouteBEchonetLiteHandlerFactory factory, Action<SkStackRouteBSessionConfiguration> configureRouteBSessionConfiguration) {}
+  }
+
+  public abstract class SkStackRouteBEchonetLiteHandlerFactory : ISkStackRouteBEchonetLiteHandlerFactory {
+    protected SkStackRouteBEchonetLiteHandlerFactory(IServiceCollection services) {}
+
+    public Action<SkStackRouteBSessionConfiguration>? ConfigureRouteBSessionConfiguration { get; set; }
+    protected abstract SkStackRouteBTransportProtocol TransportProtocol { get; }
+
+    public virtual async ValueTask<RouteBEchonetLiteHandler> CreateAsync(CancellationToken cancellationToken) {}
+    protected abstract ValueTask<SkStackClient> CreateClientAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken);
+  }
+
+  public sealed class SkStackRouteBSessionConfiguration : ICloneable {
+    public SkStackRouteBSessionConfiguration() {}
+
+    public SkStackActiveScanOptions? ActiveScanOptions { get; set; }
+    public SkStackChannel? Channel { get; set; }
+    public IPAddress? PaaAddress { get; set; }
+    public PhysicalAddress? PaaMacAddress { get; set; }
+    public int? PanId { get; set; }
+
+    public SkStackRouteBSessionConfiguration Clone() {}
+    object ICloneable.Clone() {}
+  }
+
+  public sealed class SkStackRouteBTcpEchonetLiteHandler : SkStackRouteBEchonetLiteHandler {
+    public SkStackRouteBTcpEchonetLiteHandler(SkStackClient client, SkStackRouteBSessionConfiguration sessionConfiguration, bool shouldDisposeClient = false, IServiceProvider? serviceProvider = null) {}
+  }
+
+  public sealed class SkStackRouteBUdpEchonetLiteHandler : SkStackRouteBEchonetLiteHandler {
+    public SkStackRouteBUdpEchonetLiteHandler(SkStackClient client, SkStackRouteBSessionConfiguration sessionConfiguration, bool shouldDisposeClient = false, IServiceProvider? serviceProvider = null) {}
+  }
+}
+// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.4.1.0.
+// Smdn.Reflection.ReverseGenerating.ListApi.Core v1.3.1.0 (https://github.com/smdn/Smdn.Reflection.ReverseGenerating)


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #7](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/8570742834).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1`
- package_prevver_ref: `9768cf0dd6aee5ee3bf82a705b7439975fd22ca6`
- package_prevver_tag: -
- package_id: `Smdn.Net.EchonetLite.RouteB.SkStackIP`
- package_id_with_version: `Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1`
- package_version: `2.0.0-preview1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1-1712324397`
- release_tag: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/48cbacb2c9553f7183a4e61facfc2926`](https://gist.github.com/smdn/48cbacb2c9553f7183a4e61facfc2926)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.RouteB.SkStackIP.2.0.0-preview1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.


