### PR TITLE
Release main/Smdn.Net.EchonetLite.RouteB-2.0.0-preview2

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-net6.0.apilist.cs
@@ -1,11 +1,11 @@
-// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview1)
+// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview2)
 //   Name: Smdn.Net.EchonetLite.RouteB
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+72e57d7daf6b52fc6ecc4ed745e175a1893e8d90
+//   InformationalVersion: 2.0.0-preview2+c9161acca48757584c059440b4e2b704c3a80505
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
-//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
 //     System.Memory, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Net.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
@@ -36,8 +36,9 @@ namespace Smdn.Net.EchonetLite.RouteB.Credentials {
   }
 
   public static class RouteBCredentialServiceCollectionExtensions {
-    public static IServiceCollection AddRouteBCredential(this IServiceCollection services, IRouteBCredentialProvider credentialProvider) {}
     public static IServiceCollection AddRouteBCredential(this IServiceCollection services, string id, string password) {}
+    public static IServiceCollection AddRouteBCredentialFromEnvironmentVariable(this IServiceCollection services, string envVarForId, string envVarForPassword) {}
+    public static IServiceCollection AddRouteBCredentialProvider(this IServiceCollection services, IRouteBCredentialProvider credentialProvider) {}
   }
 
   public static class RouteBCredentials {

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-net8.0.apilist.cs
@@ -1,11 +1,11 @@
-// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview1)
+// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview2)
 //   Name: Smdn.Net.EchonetLite.RouteB
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+72e57d7daf6b52fc6ecc4ed745e175a1893e8d90
+//   InformationalVersion: 2.0.0-preview2+c9161acca48757584c059440b4e2b704c3a80505
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
-//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
 //     System.Memory, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Net.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
@@ -36,8 +36,9 @@ namespace Smdn.Net.EchonetLite.RouteB.Credentials {
   }
 
   public static class RouteBCredentialServiceCollectionExtensions {
-    public static IServiceCollection AddRouteBCredential(this IServiceCollection services, IRouteBCredentialProvider credentialProvider) {}
     public static IServiceCollection AddRouteBCredential(this IServiceCollection services, string id, string password) {}
+    public static IServiceCollection AddRouteBCredentialFromEnvironmentVariable(this IServiceCollection services, string envVarForId, string envVarForPassword) {}
+    public static IServiceCollection AddRouteBCredentialProvider(this IServiceCollection services, IRouteBCredentialProvider credentialProvider) {}
   }
 
   public static class RouteBCredentials {

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-netstandard2.1.apilist.cs
@@ -1,11 +1,11 @@
-// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview1)
+// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview2)
 //   Name: Smdn.Net.EchonetLite.RouteB
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+72e57d7daf6b52fc6ecc4ed745e175a1893e8d90
+//   InformationalVersion: 2.0.0-preview2+c9161acca48757584c059440b4e2b704c3a80505
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
-//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
@@ -34,8 +34,9 @@ namespace Smdn.Net.EchonetLite.RouteB.Credentials {
   }
 
   public static class RouteBCredentialServiceCollectionExtensions {
-    public static IServiceCollection AddRouteBCredential(this IServiceCollection services, IRouteBCredentialProvider credentialProvider) {}
     public static IServiceCollection AddRouteBCredential(this IServiceCollection services, string id, string password) {}
+    public static IServiceCollection AddRouteBCredentialFromEnvironmentVariable(this IServiceCollection services, string envVarForId, string envVarForPassword) {}
+    public static IServiceCollection AddRouteBCredentialProvider(this IServiceCollection services, IRouteBCredentialProvider credentialProvider) {}
   }
 
   public static class RouteBCredentials {


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #9](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/9732262485).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.RouteB-2.0.0-preview2`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite.RouteB-2.0.0-preview1`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite.RouteB-2.0.0-preview1`
- package_id: `Smdn.Net.EchonetLite.RouteB`
- package_id_with_version: `Smdn.Net.EchonetLite.RouteB-2.0.0-preview2`
- package_version: `2.0.0-preview2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.RouteB-2.0.0-preview2-1719752938`
- release_tag: `releases/Smdn.Net.EchonetLite.RouteB-2.0.0-preview2`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/2c6a8722d46b34f3bcf6410211c4ac11`](https://gist.github.com/smdn/2c6a8722d46b34f3bcf6410211c4ac11)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.RouteB.2.0.0-preview2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.


