### PR TITLE
Release main/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1)
+// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2)
 //   Name: Smdn.Net.EchonetLite.RouteB.SkStackIP
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+93509882219e05b5d6a8c897a8bdfee251761d59
+//   InformationalVersion: 2.0.0-preview2+4d034f0903ea62ea00625815ef039b64f3ec2917
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -11,7 +11,7 @@
 //     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
 //     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.SkStackIP, Version=1.0.0.0, Culture=neutral
+//     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
 //     System.ComponentModel, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Memory, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1)
+// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2)
 //   Name: Smdn.Net.EchonetLite.RouteB.SkStackIP
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+93509882219e05b5d6a8c897a8bdfee251761d59
+//   InformationalVersion: 2.0.0-preview2+4d034f0903ea62ea00625815ef039b64f3ec2917
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -11,7 +11,7 @@
 //     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
 //     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.SkStackIP, Version=1.0.0.0, Culture=neutral
+//     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Memory, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1)
+// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2)
 //   Name: Smdn.Net.EchonetLite.RouteB.SkStackIP
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+93509882219e05b5d6a8c897a8bdfee251761d59
+//   InformationalVersion: 2.0.0-preview2+4d034f0903ea62ea00625815ef039b64f3ec2917
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -11,7 +11,7 @@
 //     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
 //     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.SkStackIP, Version=1.0.0.0, Culture=neutral
+//     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #10](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/9732338711).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview1`
- package_id: `Smdn.Net.EchonetLite.RouteB.SkStackIP`
- package_id_with_version: `Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2`
- package_version: `2.0.0-preview2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2-1719753611`
- release_tag: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/e122dce23cc480e38f08e4dbe82d361b`](https://gist.github.com/smdn/e122dce23cc480e38f08e4dbe82d361b)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.RouteB.SkStackIP.2.0.0-preview2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.


