### PR TITLE
Release main/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview1)
+// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2)
 //   Name: Smdn.Net.EchonetLite.RouteB.BP35XX
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+7e4ec0f9f1fc7e96046c9643ab2a9a07aa113c90
+//   InformationalVersion: 2.0.0-preview2+aaf89dd76b82384b6126644a027a919432f09930
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -9,7 +9,7 @@
 //     Smdn.Devices.BP35XX, Version=1.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.RouteB.SkStackIP, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.SkStackIP, Version=1.0.0.0, Culture=neutral
+//     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
 //     System.ComponentModel, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Runtime, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 #nullable enable annotations

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview1)
+// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2)
 //   Name: Smdn.Net.EchonetLite.RouteB.BP35XX
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+7e4ec0f9f1fc7e96046c9643ab2a9a07aa113c90
+//   InformationalVersion: 2.0.0-preview2+aaf89dd76b82384b6126644a027a919432f09930
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -9,7 +9,7 @@
 //     Smdn.Devices.BP35XX, Version=1.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.RouteB.SkStackIP, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.SkStackIP, Version=1.0.0.0, Culture=neutral
+//     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 #nullable enable annotations

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview1)
+// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2)
 //   Name: Smdn.Net.EchonetLite.RouteB.BP35XX
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+7e4ec0f9f1fc7e96046c9643ab2a9a07aa113c90
+//   InformationalVersion: 2.0.0-preview2+aaf89dd76b82384b6126644a027a919432f09930
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -9,7 +9,7 @@
 //     Smdn.Devices.BP35XX, Version=1.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.RouteB.SkStackIP, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.SkStackIP, Version=1.0.0.0, Culture=neutral
+//     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #11](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/9732391750).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview1`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview1`
- package_id: `Smdn.Net.EchonetLite.RouteB.BP35XX`
- package_id_with_version: `Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2`
- package_version: `2.0.0-preview2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2-1719754108`
- release_tag: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/d05187638da45c1cbf927a78659992fd`](https://gist.github.com/smdn/d05187638da45c1cbf927a78659992fd)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.RouteB.BP35XX.2.0.0-preview2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.


