### PR TITLE
Release main/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2)
+// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3)
 //   Name: Smdn.Net.EchonetLite.RouteB.BP35XX
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview2+aaf89dd76b82384b6126644a027a919432f09930
+//   InformationalVersion: 2.0.0-preview3+f083b2de6dc07603893bff9d4a263609fd1a919e
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2)
+// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3)
 //   Name: Smdn.Net.EchonetLite.RouteB.BP35XX
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview2+aaf89dd76b82384b6126644a027a919432f09930
+//   InformationalVersion: 2.0.0-preview3+f083b2de6dc07603893bff9d4a263609fd1a919e
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2)
+// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3)
 //   Name: Smdn.Net.EchonetLite.RouteB.BP35XX
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview2+aaf89dd76b82384b6126644a027a919432f09930
+//   InformationalVersion: 2.0.0-preview3+f083b2de6dc07603893bff9d4a263609fd1a919e
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #12](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/10738294218).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2`
- package_id: `Smdn.Net.EchonetLite.RouteB.BP35XX`
- package_id_with_version: `Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3`
- package_version: `2.0.0-preview3`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3-1725625458`
- release_tag: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/b18e27b3ee491a4c5b162e8b158d8a3b`](https://gist.github.com/smdn/b18e27b3ee491a4c5b162e8b158d8a3b)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.RouteB.BP35XX.2.0.0-preview3.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.EchonetLite.RouteB.BP35XX.latest.nuspec
+++ Smdn.Net.EchonetLite.RouteB.BP35XX.2.0.0-preview3.nuspec
@@ -1,33 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.EchonetLite.RouteB.BP35XX</id>
-    <version>2.0.0-preview2</version>
+    <version>2.0.0-preview3</version>
     <title>Smdn.Net.EchonetLite.RouteB.BP35XX</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.EchonetLite.RouteB.BP35XX.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</projectUrl>
-    <description>BP35A1???Skyley Networks?[SKSTACK IP](https://www.skyley.com/wiki/?SKSTACK+IP+for+HAN)?????[ROHM Wi-SUN?????](https://www.rohm.co.jp/products/wireless-communication/specified-low-power-radio-modules)????????????????????????????B????????ECHONET Lite???????????API??????? ECHONET Lite???????????????????????????????`BP35A1RouteBEchonetLiteHandlerFactory`???????API???????</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview2</releaseNotes>
-    <copyright>Copyright � 2024 smdn</copyright>
+    <description>BP35A1など、Skyley Networksの[SKSTACK IP](https://www.skyley.com/wiki/?SKSTACK+IP+for+HAN)を搭載する[ROHM Wi-SUNモジュール](https://www.rohm.co.jp/products/wireless-communication/specified-low-power-radio-modules)を使用して、スマート電力量メータとの情報伝達手段である「Bルート」を介したECHONET Lite規格の通信を扱うためのAPIを提供します。 ECHONET Lite規格における下位通信層に相当する実装を作成するファクトリクラス`BP35A1RouteBEchonetLiteHandlerFactory`をはじめとするAPIを提供します。</description>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3</releaseNotes>
+    <copyright>Copyright © 2024 smdn</copyright>
     <tags>smdn.jp SKSTACK SKSTACK-IP Route-B B-Route Wi-SUN BP35A1 ROHM-BP35A1 ECHONET ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" branch="main" commit="aaf89dd76b82384b6126644a027a919432f09930" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" commit="f083b2de6dc07603893bff9d4a263609fd1a919e" />
     <dependencies>
       <group targetFramework="net6.0">
-        <dependency id="Smdn.Devices.BP35XX" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Devices.BP35XX" version="[1.0.0, 3.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.EchonetLite.RouteB.SkStackIP" version="2.0.0-preview2" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Smdn.Devices.BP35XX" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Devices.BP35XX" version="[1.0.0, 3.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.EchonetLite.RouteB.SkStackIP" version="2.0.0-preview2" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
-        <dependency id="Smdn.Devices.BP35XX" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Devices.BP35XX" version="[1.0.0, 3.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.EchonetLite.RouteB.SkStackIP" version="2.0.0-preview2" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/net6.0/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" target="lib/net6.0/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/net6.0/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" target="lib/net6.0/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.Net.EchonetLite.RouteB.BP35XX.png" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

