### PR TITLE
ECHONET Lite電文処理におけるプロパティ関連の用語を整理する

### DIFF
--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/Format1Message.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/Format1Message.cs
@@ -125,12 +125,12 @@ public readonly struct Format1Message {
   /// </summary>
   /// <exception cref="InvalidOperationException">
   /// <see cref="ESV"/>が<see cref="ESV.SetGet"/>, <see cref="ESV.SetGetResponse"/>, <see cref="ESV.SetGetServiceNotAvailable"/>のいずれかです。
-  /// 代わりに<see cref="GetOPCSetGetList"/>を呼び出してください。
+  /// 代わりに<see cref="GetPropertiesForSetAndGet"/>を呼び出してください。
   /// </exception>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２ 電文構成
   /// </seealso>
-  public IReadOnlyCollection<PropertyRequest> GetOPCList()
+  public IReadOnlyCollection<PropertyRequest> GetProperties()
   {
     if (IsWriteOrReadService)
       throw new InvalidOperationException($"invalid operation for the ESV of the current instance (ESV={ESV})");
@@ -148,16 +148,16 @@ public readonly struct Format1Message {
   /// </summary>
   /// <exception cref="InvalidOperationException">
   /// <see cref="ESV"/>が<see cref="ESV.SetGet"/>, <see cref="ESV.SetGetResponse"/>, <see cref="ESV.SetGetServiceNotAvailable"/>のいずれでもありません。
-  /// 代わりに<see cref="GetOPCList"/>を呼び出してください。
+  /// 代わりに<see cref="GetProperties"/>を呼び出してください。
   /// </exception>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２ 電文構成
   /// </seealso>
   public (
-    IReadOnlyCollection<PropertyRequest> OPCSetList,
-    IReadOnlyCollection<PropertyRequest> OPCGetList
+    IReadOnlyCollection<PropertyRequest> PropertiesForSet,
+    IReadOnlyCollection<PropertyRequest> PropertiesForGet
   )
-  GetOPCSetGetList()
+  GetPropertiesForSetAndGet()
   {
     if (!IsWriteOrReadService)
       throw new InvalidOperationException($"invalid operation for the ESV of the current instance (ESV={ESV})");

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/Format1Message.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/Format1Message.cs
@@ -51,17 +51,17 @@ public readonly struct Format1Message {
   /// <see cref="ESV"/>が<see cref="ESV.SetGet"/>, <see cref="ESV.SetGetResponse"/>, <see cref="ESV.SetGetServiceNotAvailable"/>のいずれかの場合は、Set操作に対応する処理対象プロパティのコレクション。
   /// そうでない場合は、<see cref="ESV"/>で指定されるサービスにおいて処理対象となるプロパティのコレクション。
   /// </summary>
-  private readonly IReadOnlyCollection<PropertyRequest> opcListOrOpcSetList;
+  private readonly IReadOnlyCollection<PropertyRequest> propsForSetOrGet;
 
   /// <summary>
   /// <see cref="ESV"/>が<see cref="ESV.SetGet"/>, <see cref="ESV.SetGetResponse"/>, <see cref="ESV.SetGetServiceNotAvailable"/>のいずれかの場合は、Get操作に対応する処理対象プロパティのコレクション。
   /// そうでない場合は、<see langword="null"/>。
   /// </summary>
-  private readonly IReadOnlyCollection<PropertyRequest>? opcGetList;
+  private readonly IReadOnlyCollection<PropertyRequest>? propsForGet;
 
   [JsonIgnore]
 #if SYSTEM_DIAGNOSTICS_CODEANALYSIS_MEMBERNOTNULLWHENATTRIBUTE
-  [MemberNotNullWhen(true, nameof(opcGetList))]
+  [MemberNotNullWhen(true, nameof(propsForGet))]
 #endif
   private bool IsWriteOrReadService => FrameSerializer.IsESVWriteOrReadService(ESV);
 
@@ -74,13 +74,13 @@ public readonly struct Format1Message {
   /// <param name="seoj"><see cref="SEOJ"/>に指定する値。</param>
   /// <param name="deoj"><see cref="DEOJ"/>に指定する値。</param>
   /// <param name="esv"><see cref="ESV"/>に指定する値。</param>
-  /// <param name="opcList"><paramref name="esv"/>で指定されるサービスにおいて処理対象となるプロパティ(<see cref="PropertyRequest"/>)のコレクションを表す<see cref="IReadOnlyCollection{PropertyRequest}"/>を指定します。</param>
+  /// <param name="properties"><paramref name="esv"/>で指定されるサービスにおいて処理対象となるプロパティ(<see cref="PropertyRequest"/>)のコレクションを表す<see cref="IReadOnlyCollection{PropertyRequest}"/>を指定します。</param>
   /// <exception cref="ArgumentException">
   /// <paramref name="esv"/>が<see cref="ESV.SetGet"/>, <see cref="ESV.SetGetResponse"/>, <see cref="ESV.SetGetServiceNotAvailable"/>のいずれかです。
   /// この場合、Set操作とGet操作のそれぞれに対応する処理対象プロパティのコレクションを指定する必要があります。
   /// </exception>
-  /// <exception cref="ArgumentNullException"><paramref name="opcList"/>が<see langword="null"/>です。</exception>
-  public Format1Message(EOJ seoj, EOJ deoj, ESV esv, IReadOnlyCollection<PropertyRequest> opcList)
+  /// <exception cref="ArgumentNullException"><paramref name="properties"/>が<see langword="null"/>です。</exception>
+  public Format1Message(EOJ seoj, EOJ deoj, ESV esv, IReadOnlyCollection<PropertyRequest> properties)
   {
     if (FrameSerializer.IsESVWriteOrReadService(esv))
       throw new ArgumentException(message: $"ESV must be other than {nameof(ESV.SetGet)}, {nameof(ESV.SetGetResponse)}, or {nameof(ESV.SetGetServiceNotAvailable)}.", paramName: nameof(esv));
@@ -88,7 +88,7 @@ public readonly struct Format1Message {
     SEOJ = seoj;
     DEOJ = deoj;
     ESV = esv;
-    opcListOrOpcSetList = opcList ?? throw new ArgumentNullException(nameof(opcList));
+    propsForSetOrGet = properties ?? throw new ArgumentNullException(nameof(properties));
   }
 
   /// <summary>
@@ -100,14 +100,14 @@ public readonly struct Format1Message {
   /// <param name="seoj"><see cref="SEOJ"/>に指定する値。</param>
   /// <param name="deoj"><see cref="DEOJ"/>に指定する値。</param>
   /// <param name="esv"><see cref="ESV"/>に指定する値。</param>
-  /// <param name="opcSetList"><paramref name="esv"/>で指定されるサービスのSet操作において処理対象となるプロパティ(<see cref="PropertyRequest"/>)のコレクションを表す<see cref="IReadOnlyCollection{PropertyRequest}"/>を指定します。</param>
-  /// <param name="opcGetList"><paramref name="esv"/>で指定されるサービスのGet操作において処理対象となるプロパティ(<see cref="PropertyRequest"/>)のコレクションを表す<see cref="IReadOnlyCollection{PropertyRequest}"/>を指定します。</param>
+  /// <param name="propertiesForSet"><paramref name="esv"/>で指定されるサービスのSet操作において処理対象となるプロパティ(<see cref="PropertyRequest"/>)のコレクションを表す<see cref="IReadOnlyCollection{PropertyRequest}"/>を指定します。</param>
+  /// <param name="propertiesForGet"><paramref name="esv"/>で指定されるサービスのGet操作において処理対象となるプロパティ(<see cref="PropertyRequest"/>)のコレクションを表す<see cref="IReadOnlyCollection{PropertyRequest}"/>を指定します。</param>
   /// <exception cref="ArgumentException">
   /// <paramref name="esv"/>が<see cref="ESV.SetGet"/>, <see cref="ESV.SetGetResponse"/>, <see cref="ESV.SetGetServiceNotAvailable"/>のいずれかではありません。
   /// この場合、Set操作またはGet操作のどちらかに対応する処理対象プロパティのコレクションのみを指定する必要があります。
   /// </exception>
-  /// <exception cref="ArgumentNullException"><paramref name="opcSetList"/>もしくは<paramref name="opcGetList"/>が<see langword="null"/>です。</exception>
-  public Format1Message(EOJ seoj, EOJ deoj, ESV esv, IReadOnlyCollection<PropertyRequest> opcSetList, IReadOnlyCollection<PropertyRequest> opcGetList)
+  /// <exception cref="ArgumentNullException"><paramref name="propertiesForSet"/>もしくは<paramref name="propertiesForGet"/>が<see langword="null"/>です。</exception>
+  public Format1Message(EOJ seoj, EOJ deoj, ESV esv, IReadOnlyCollection<PropertyRequest> propertiesForSet, IReadOnlyCollection<PropertyRequest> propertiesForGet)
   {
     if (!FrameSerializer.IsESVWriteOrReadService(esv))
       throw new ArgumentException(message: $"ESV must be {nameof(ESV.SetGet)}, {nameof(ESV.SetGetResponse)}, or {nameof(ESV.SetGetServiceNotAvailable)}.", paramName: nameof(esv));
@@ -115,8 +115,8 @@ public readonly struct Format1Message {
     SEOJ = seoj;
     DEOJ = deoj;
     ESV = esv;
-    opcListOrOpcSetList = opcSetList ?? throw new ArgumentNullException(nameof(opcSetList));
-    this.opcGetList = opcGetList ?? throw new ArgumentNullException(nameof(opcGetList));
+    propsForSetOrGet = propertiesForSet ?? throw new ArgumentNullException(nameof(propertiesForSet));
+    propsForGet = propertiesForGet ?? throw new ArgumentNullException(nameof(propertiesForGet));
   }
 
   /// <summary>
@@ -136,9 +136,9 @@ public readonly struct Format1Message {
       throw new InvalidOperationException($"invalid operation for the ESV of the current instance (ESV={ESV})");
 
 #if SYSTEM_DIAGNOSTICS_CODEANALYSIS_MEMBERNOTNULLWHENATTRIBUTE
-    return opcListOrOpcSetList;
+    return propsForSetOrGet;
 #else
-    return opcListOrOpcSetList!;
+    return propsForSetOrGet!;
 #endif
   }
 
@@ -163,9 +163,9 @@ public readonly struct Format1Message {
       throw new InvalidOperationException($"invalid operation for the ESV of the current instance (ESV={ESV})");
 
 #if SYSTEM_DIAGNOSTICS_CODEANALYSIS_MEMBERNOTNULLWHENATTRIBUTE
-    return (opcListOrOpcSetList, opcGetList);
+    return (propsForSetOrGet, propsForGet);
 #else
-    return (opcListOrOpcSetList!, opcGetList!);
+    return (propsForSetOrGet!, propsForGet!);
 #endif
   }
 }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Deserialization.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Deserialization.cs
@@ -65,34 +65,34 @@ partial class FrameSerializer {
       // ECHONET Liteプロパティ(1B)
       // EDTのバイト数(1B)
       // プロパティ値データ(PDCで指定)
-      if (!TryParseProcessingTargetProperties(bytes, out var opcSetList, out var bytesReadForOPCSetList))
+      if (!TryParseProcessingTargetProperties(bytes, out var propsForSet, out var bytesReadForSetProps))
         return false;
 
-      bytes = bytes.Slice(bytesReadForOPCSetList);
+      bytes = bytes.Slice(bytesReadForSetProps);
 
       // OPCGet 処理プロパティ数(1B)
       // ECHONET Liteプロパティ(1B)
       // EDTのバイト数(1B)
       // プロパティ値データ(PDCで指定)
-      if (!TryParseProcessingTargetProperties(bytes, out var opcGetList, out _ /* var bytesReadForOPCGetList */))
+      if (!TryParseProcessingTargetProperties(bytes, out var propsForGet, out _ /* var bytesReadForGetProps */))
         return false;
 
       message = new(
         seoj,
         deoj,
         esv,
-        opcSetList,
-        opcGetList
+        propsForSet,
+        propsForGet
       );
 
-      // bytes = bytes.Slice(bytesReadForOPCGetList);
+      // bytes = bytes.Slice(bytesReadForGetProps);
     }
     else {
       // OPC 処理プロパティ数(1B)
       // ECHONET Liteプロパティ(1B)
       // EDTのバイト数(1B)
       // プロパティ値データ(PDCで指定)
-      if (!TryParseProcessingTargetProperties(bytes, out var opcList, out _ /* var bytesRead */))
+      if (!TryParseProcessingTargetProperties(bytes, out var props, out _ /* var bytesRead */))
         return false;
 
       // bytes = bytes.Slice(bytesRead);
@@ -101,7 +101,7 @@ partial class FrameSerializer {
         seoj,
         deoj,
         esv,
-        opcList
+        props
       );
     }
 

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Serialization.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Serialization.cs
@@ -11,8 +11,89 @@ namespace Smdn.Net.EchonetLite.Protocol;
 #pragma warning disable IDE0040
 partial class FrameSerializer {
 #pragma warning restore IDE0040
-  [CLSCompliant(false)]
+  /// <summary>
+  /// 引数で与えられた値をもとに、ECHONET Liteフレームの電文形式 1（規定電文形式）の電文をシリアライズして<see cref="IBufferWriter{Byte}"/>へ書き込みます
+  /// </summary>
+  /// <param name="buffer">電文の書き込み先となる<see cref="IBufferWriter{Byte}"/>。</param>
+  /// <param name="tid">トランザクションIDを表す<see cref="int"/>。　この値を<see cref="ushort"/>にキャストした値がシリアライズされます。</param>
+  /// <param name="sourceObject">送信元のECHONET オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="destinationObject">相手先のECHONET オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="esv">ECHONET Lite サービスを表す<see cref="ESV"/>。</param>
+  /// <param name="properties">処理対象プロパティを表す<see cref="PropertyRequest"/>のコレクション。</param>
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="buffer"/>が<see langword="null"/>です。
+  /// または、<paramref name="properties"/>が<see langword="null"/>です。
+  /// </exception>
+  /// <exception cref="ArgumentException">
+  /// <paramref name="esv"/>が<see cref="ESV.SetGet"/>, <see cref="ESV.SetGetResponse"/>, <see cref="ESV.SetGetServiceNotAvailable"/>のいずれかです。
+  /// Set操作とGet操作に対応するプロパティを指定するために、代わりに<see cref="SerializeEchonetLiteFrameFormat1(IBufferWriter{byte}, int, EOJ, EOJ, ESV, IEnumerable{PropertyRequest}, IEnumerable{PropertyRequest})"/>を呼び出してください。
+  /// </exception>
+  /// <exception cref="InvalidOperationException">
+  /// <paramref name="esv"/>で指定されるECHONET Lite サービスサービスでは、<paramref name="properties"/>で指定されるプロパティの数を0にすることはできません。
+  /// </exception>
   public static void SerializeEchonetLiteFrameFormat1(
+    IBufferWriter<byte> buffer,
+    int tid,
+    EOJ sourceObject,
+    EOJ destinationObject,
+    ESV esv,
+    IEnumerable<PropertyRequest> properties
+  )
+  {
+    if (IsESVWriteOrReadService(esv))
+      throw new ArgumentException(message: $"ESV must be other than {nameof(ESV.SetGet)}, {nameof(ESV.SetGetResponse)}, or {nameof(ESV.SetGetServiceNotAvailable)}.", paramName: nameof(esv));
+
+    SerializeEchonetLiteFrameFormat1(
+      buffer: buffer ?? throw new ArgumentNullException(nameof(buffer)),
+      tid: unchecked((ushort)tid),
+      sourceObject: sourceObject,
+      destinationObject: destinationObject,
+      esv: esv,
+      propsForSetOrGet: properties ?? throw new ArgumentNullException(nameof(properties)),
+      propsForGet: null
+    );
+  }
+
+  /// <summary>
+  /// 引数で与えられた値をもとに、ECHONET Liteフレームの電文形式 1（規定電文形式）の電文をシリアライズして<see cref="IBufferWriter{Byte}"/>へ書き込みます
+  /// </summary>
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="buffer"/>が<see langword="null"/>です。
+  /// または、<paramref name="propertiesForSet"/>が<see langword="null"/>です。
+  /// または、<paramref name="propertiesForGet"/>が<see langword="null"/>です。
+  /// </exception>
+  /// <exception cref="ArgumentException">
+  /// <paramref name="esv"/>が<see cref="ESV.SetGet"/>, <see cref="ESV.SetGetResponse"/>, <see cref="ESV.SetGetServiceNotAvailable"/>のいずれでもありません。
+  /// 代わりに<see cref="SerializeEchonetLiteFrameFormat1(IBufferWriter{byte}, int, EOJ, EOJ, ESV, IEnumerable{PropertyRequest})"/>を呼び出してください。
+  /// </exception>
+  /// <exception cref="InvalidOperationException">
+  /// <paramref name="esv"/>で指定されるECHONET Lite サービスサービスでは、<paramref name="propertiesForSet"/>または<paramref name="propertiesForGet"/>で指定されるプロパティの数を0にすることはできません。
+  /// </exception>
+  public static void SerializeEchonetLiteFrameFormat1(
+    IBufferWriter<byte> buffer,
+    int tid,
+    EOJ sourceObject,
+    EOJ destinationObject,
+    ESV esv,
+    IEnumerable<PropertyRequest> propertiesForSet,
+    IEnumerable<PropertyRequest> propertiesForGet
+  )
+  {
+    if (!IsESVWriteOrReadService(esv))
+      throw new ArgumentException(message: $"ESV must be {nameof(ESV.SetGet)}, {nameof(ESV.SetGetResponse)}, or {nameof(ESV.SetGetServiceNotAvailable)}.", paramName: nameof(esv));
+
+    SerializeEchonetLiteFrameFormat1(
+      buffer: buffer ?? throw new ArgumentNullException(nameof(buffer)),
+      tid: unchecked((ushort)tid),
+      sourceObject: sourceObject,
+      destinationObject: destinationObject,
+      esv: esv,
+      propsForSetOrGet: propertiesForSet ?? throw new ArgumentNullException(nameof(propertiesForSet)),
+      propsForGet: propertiesForGet ?? throw new ArgumentNullException(nameof(propertiesForGet))
+    );
+  }
+
+  private static void SerializeEchonetLiteFrameFormat1(
     IBufferWriter<byte> buffer,
     ushort tid,
     EOJ sourceObject,
@@ -22,11 +103,6 @@ partial class FrameSerializer {
     IEnumerable<PropertyRequest>? propsForGet = null
   )
   {
-    if (buffer is null)
-      throw new ArgumentNullException(nameof(buffer));
-    if (propsForSetOrGet is null)
-      throw new ArgumentNullException(nameof(propsForSetOrGet));
-
     WriteEchonetLiteEHDAndTID(buffer, EHD1.EchonetLite, EHD2.Format1, tid);
 
     WriteEOJ(buffer, sourceObject); // SEOJ
@@ -48,17 +124,15 @@ partial class FrameSerializer {
     if (!TryWriteEDataType1ProcessingTargetProperties(buffer, propsForSetOrGet, failIfEmpty: failIfOpcSetOrOpcGetIsZero))
       throw new InvalidOperationException("OPCSet can not be zero when ESV is other than SetGet_SNA.");
 
-    if (IsESVWriteOrReadService(esv)) {
-      if (propsForGet is null)
-        throw new ArgumentNullException(nameof(propsForGet));
+    // OPCGet 処理プロパティ数(1B)
+    // ECHONET Liteプロパティ(1B)
+    // EDTのバイト数(1B)
+    // プロパティ値データ(PDCで指定)
+    if (propsForGet is null)
+      return;
 
-      // OPCGet 処理プロパティ数(1B)
-      // ECHONET Liteプロパティ(1B)
-      // EDTのバイト数(1B)
-      // プロパティ値データ(PDCで指定)
-      if (!TryWriteEDataType1ProcessingTargetProperties(buffer, propsForGet, failIfEmpty: failIfOpcSetOrOpcGetIsZero))
-        throw new InvalidOperationException("OPCGet can not be zero when ESV is other than SetGet_SNA.");
-    }
+    if (!TryWriteEDataType1ProcessingTargetProperties(buffer, propsForGet, failIfEmpty: failIfOpcSetOrOpcGetIsZero))
+      throw new InvalidOperationException("OPCGet can not be zero when ESV is other than SetGet_SNA.");
   }
 
   [CLSCompliant(false)]

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Services.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Services.cs
@@ -297,7 +297,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.SetI,
-        propsForSetOrGet: properties.Select(ConvertToPropertyRequest)
+        properties: properties.Select(ConvertToPropertyRequest)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -413,7 +413,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.SetC,
-        propsForSetOrGet: properties.Select(ConvertToPropertyRequest)
+        properties: properties.Select(ConvertToPropertyRequest)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -520,7 +520,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.Get,
-        propsForSetOrGet: properties.Select(ConvertToPropertyRequestExceptValueData)
+        properties: properties.Select(ConvertToPropertyRequestExceptValueData)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -644,8 +644,8 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.SetGet,
-        propsForSetOrGet: propertiesSet.Select(ConvertToPropertyRequest),
-        propsForGet: propertiesGet.Select(ConvertToPropertyRequestExceptValueData)
+        propertiesForSet: propertiesSet.Select(ConvertToPropertyRequest),
+        propertiesForGet: propertiesGet.Select(ConvertToPropertyRequestExceptValueData)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -707,7 +707,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.InfRequest,
-        propsForSetOrGet: properties.Select(ConvertToPropertyRequestExceptValueData)
+        properties: properties.Select(ConvertToPropertyRequestExceptValueData)
       ),
       cancellationToken
     );
@@ -758,7 +758,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.Inf,
-        propsForSetOrGet: properties.Select(ConvertToPropertyRequest)
+        properties: properties.Select(ConvertToPropertyRequest)
       ),
       cancellationToken
     );
@@ -839,7 +839,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.InfC,
-        propsForSetOrGet: properties.Select(ConvertToPropertyRequest)
+        properties: properties.Select(ConvertToPropertyRequest)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -1213,7 +1213,7 @@ partial class EchonetClient
           sourceObject: message.DEOJ, // 入れ替え
           destinationObject: message.SEOJ, // 入れ替え
           esv: ESV.SetIServiceNotAvailable, // SetI_SNA(0x50)
-          propsForSetOrGet: responseProps
+          properties: responseProps
         ),
         cancellationToken: default
       ).ConfigureAwait(false);
@@ -1291,7 +1291,7 @@ partial class EchonetClient
           sourceObject: message.DEOJ, // 入れ替え
           destinationObject: message.SEOJ, // 入れ替え
           esv: ESV.SetCServiceNotAvailable, // SetC_SNA(0x51)
-          propsForSetOrGet: responseProps
+          properties: responseProps
         ),
         cancellationToken: default
       ).ConfigureAwait(false);
@@ -1307,7 +1307,7 @@ partial class EchonetClient
         sourceObject: message.DEOJ, // 入れ替え
         destinationObject: message.SEOJ, // 入れ替え
         esv: ESV.SetResponse, // Set_Res(0x71)
-        propsForSetOrGet: responseProps
+        properties: responseProps
       ),
       cancellationToken: default
     ).ConfigureAwait(false);
@@ -1382,7 +1382,7 @@ partial class EchonetClient
           sourceObject: message.DEOJ, // 入れ替え
           destinationObject: message.SEOJ, // 入れ替え
           esv: ESV.GetServiceNotAvailable, // Get_SNA(0x52)
-          propsForSetOrGet: responseProps
+          properties: responseProps
         ),
         cancellationToken: default
       ).ConfigureAwait(false);
@@ -1398,7 +1398,7 @@ partial class EchonetClient
         sourceObject: message.DEOJ, // 入れ替え
         destinationObject: message.SEOJ, // 入れ替え
         esv: ESV.GetResponse, // Get_Res(0x72)
-        propsForSetOrGet: responseProps
+        properties: responseProps
       ),
       cancellationToken: default
     ).ConfigureAwait(false);
@@ -1499,8 +1499,8 @@ partial class EchonetClient
           sourceObject: message.DEOJ, // 入れ替え
           destinationObject: message.SEOJ, // 入れ替え
           esv: ESV.SetGetServiceNotAvailable, // SetGet_SNA(0x5E)
-          propsForSetOrGet: responsePropsForSet,
-          propsForGet: responsePropsForGet
+          propertiesForSet: responsePropsForSet,
+          propertiesForGet: responsePropsForGet
         ),
         cancellationToken: default
       ).ConfigureAwait(false);
@@ -1516,8 +1516,8 @@ partial class EchonetClient
         sourceObject: message.DEOJ, // 入れ替え
         destinationObject: message.SEOJ, // 入れ替え
         esv: ESV.SetGetResponse, // SetGet_Res(0x7E)
-        propsForSetOrGet: responsePropsForSet,
-        propsForGet: responsePropsForGet
+        propertiesForSet: responsePropsForSet,
+        propertiesForGet: responsePropsForGet
       ),
       cancellationToken: default
     ).ConfigureAwait(false);
@@ -1694,7 +1694,7 @@ partial class EchonetClient
           sourceObject: message.DEOJ, // 入れ替え
           destinationObject: message.SEOJ, // 入れ替え
           esv: ESV.InfCResponse, // INFC_Res(0x74)
-          propsForSetOrGet: responseProps
+          properties: responseProps
         ),
         cancellationToken: default
       ).ConfigureAwait(false);

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Services.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Services.cs
@@ -266,7 +266,7 @@ partial class EchonetClient
         if (value.Message.ESV != ESV.SetIServiceNotAvailable)
           return;
 
-        var props = value.Message.GetOPCList();
+        var props = value.Message.GetProperties();
 
         foreach (var prop in props) {
           // 一部成功した書き込みを反映
@@ -382,7 +382,7 @@ partial class EchonetClient
         if (value.Message.ESV != ESV.SetCServiceNotAvailable && value.Message.ESV != ESV.SetResponse)
           return;
 
-        var props = value.Message.GetOPCList();
+        var props = value.Message.GetProperties();
 
         foreach (var prop in props) {
           // 成功した書き込みを反映
@@ -490,7 +490,7 @@ partial class EchonetClient
         if (value.Message.ESV != ESV.GetResponse && value.Message.ESV != ESV.GetServiceNotAvailable)
           return;
 
-        var props = value.Message.GetOPCList();
+        var props = value.Message.GetProperties();
 
         foreach (var prop in props) {
           // 成功した読み込みを反映
@@ -603,7 +603,7 @@ partial class EchonetClient
         if (value.Message.ESV != ESV.SetGetResponse && value.Message.ESV != ESV.SetGetServiceNotAvailable)
           return;
 
-        var (propsForSet, propsForGet) = value.Message.GetOPCSetGetList();
+        var (propsForSet, propsForGet) = value.Message.GetPropertiesForSetAndGet();
 
         foreach (var prop in propsForSet) {
           // 成功した書き込みを反映
@@ -822,7 +822,7 @@ partial class EchonetClient
         if (value.Message.ESV != ESV.InfCResponse)
           return;
 
-        responseTCS.SetResult(value.Message.GetOPCList());
+        responseTCS.SetResult(value.Message.GetProperties());
       }
       finally {
         Format1MessageReceived -= HandleINFCRes;
@@ -1180,7 +1180,7 @@ partial class EchonetClient
     }
 
     var hasError = false;
-    var requestProps = message.GetOPCList();
+    var requestProps = message.GetProperties();
     var responseProps = new List<PropertyRequest>(capacity: requestProps.Count);
 
     foreach (var prop in requestProps) {
@@ -1251,7 +1251,7 @@ partial class EchonetClient
   )
   {
     var hasError = false;
-    var requestProps = message.GetOPCList();
+    var requestProps = message.GetProperties();
     var responseProps = new List<PropertyRequest>(capacity: requestProps.Count);
 
     if (destObject is null) {
@@ -1342,7 +1342,7 @@ partial class EchonetClient
   )
   {
     var hasError = false;
-    var requestProps = message.GetOPCList();
+    var requestProps = message.GetProperties();
     var responseProps = new List<PropertyRequest>(capacity: requestProps.Count);
 
     if (destObject is null) {
@@ -1436,7 +1436,7 @@ partial class EchonetClient
   )
   {
     var hasError = false;
-    var (requestPropsForSet, requestPropsForGet) = message.GetOPCSetGetList();
+    var (requestPropsForSet, requestPropsForGet) = message.GetPropertiesForSetAndGet();
     var responsePropsForSet = new List<PropertyRequest>(capacity: requestPropsForSet.Count);
     var responsePropsForGet = new List<PropertyRequest>(capacity: requestPropsForGet.Count);
 
@@ -1557,7 +1557,7 @@ partial class EchonetClient
 #pragma warning restore IDE0060
   {
     var hasError = false;
-    var requestProps = message.GetOPCList();
+    var requestProps = message.GetProperties();
     var sourceObject = sourceNode.Devices.FirstOrDefault(d => d.EOJ == message.SEOJ);
 
     if (sourceObject is null) {
@@ -1631,7 +1631,7 @@ partial class EchonetClient
   )
   {
     var hasError = false;
-    var requestProps = message.GetOPCList();
+    var requestProps = message.GetProperties();
     var responseProps = new List<PropertyRequest>(capacity: requestProps.Count);
 
     if (destObject is null) {

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Services.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Services.cs
@@ -266,9 +266,9 @@ partial class EchonetClient
         if (value.Message.ESV != ESV.SetIServiceNotAvailable)
           return;
 
-        var opcList = value.Message.GetOPCList();
+        var props = value.Message.GetOPCList();
 
-        foreach (var prop in opcList) {
+        foreach (var prop in props) {
           // 一部成功した書き込みを反映
           var target = destinationObject.Properties.First(p => p.Spec.Code == prop.EPC);
 
@@ -278,7 +278,7 @@ partial class EchonetClient
           }
         }
 
-        responseTCS.SetResult(opcList);
+        responseTCS.SetResult(props);
 
         // TODO 一斉通知の不可応答の扱いが…
       }
@@ -297,7 +297,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.SetI,
-        opcListOrOpcSetList: properties.Select(ConvertToPropertyRequest)
+        propsForSetOrGet: properties.Select(ConvertToPropertyRequest)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -382,9 +382,9 @@ partial class EchonetClient
         if (value.Message.ESV != ESV.SetCServiceNotAvailable && value.Message.ESV != ESV.SetResponse)
           return;
 
-        var opcList = value.Message.GetOPCList();
+        var props = value.Message.GetOPCList();
 
-        foreach (var prop in opcList) {
+        foreach (var prop in props) {
           // 成功した書き込みを反映
           var target = destinationObject.Properties.First(p => p.Spec.Code == prop.EPC);
 
@@ -394,7 +394,7 @@ partial class EchonetClient
           }
         }
 
-        responseTCS.SetResult((value.Message.ESV == ESV.SetResponse, opcList));
+        responseTCS.SetResult((value.Message.ESV == ESV.SetResponse, props));
 
         // TODO 一斉通知の応答の扱いが…
       }
@@ -413,7 +413,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.SetC,
-        opcListOrOpcSetList: properties.Select(ConvertToPropertyRequest)
+        propsForSetOrGet: properties.Select(ConvertToPropertyRequest)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -490,9 +490,9 @@ partial class EchonetClient
         if (value.Message.ESV != ESV.GetResponse && value.Message.ESV != ESV.GetServiceNotAvailable)
           return;
 
-        var opcList = value.Message.GetOPCList();
+        var props = value.Message.GetOPCList();
 
-        foreach (var prop in opcList) {
+        foreach (var prop in props) {
           // 成功した読み込みを反映
           var target = destinationObject.Properties.First(p => p.Spec.Code == prop.EPC);
           if (prop.PDC != 0x00) {
@@ -501,7 +501,7 @@ partial class EchonetClient
           }
         }
 
-        responseTCS.SetResult((value.Message.ESV == ESV.GetResponse, opcList));
+        responseTCS.SetResult((value.Message.ESV == ESV.GetResponse, props));
 
         // TODO 一斉通知の応答の扱いが…
       }
@@ -520,7 +520,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.Get,
-        opcListOrOpcSetList: properties.Select(ConvertToPropertyRequestExceptValueData)
+        propsForSetOrGet: properties.Select(ConvertToPropertyRequestExceptValueData)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -603,9 +603,9 @@ partial class EchonetClient
         if (value.Message.ESV != ESV.SetGetResponse && value.Message.ESV != ESV.SetGetServiceNotAvailable)
           return;
 
-        var (opcSetList, opcGetList) = value.Message.GetOPCSetGetList();
+        var (propsForSet, propsForGet) = value.Message.GetOPCSetGetList();
 
-        foreach (var prop in opcSetList) {
+        foreach (var prop in propsForSet) {
           // 成功した書き込みを反映
           var target = destinationObject.Properties.First(p => p.Spec.Code == prop.EPC);
 
@@ -615,7 +615,7 @@ partial class EchonetClient
           }
         }
 
-        foreach (var prop in opcGetList) {
+        foreach (var prop in propsForGet) {
           // 成功した読み込みを反映
           var target = destinationObject.Properties.First(p => p.Spec.Code == prop.EPC);
 
@@ -625,7 +625,7 @@ partial class EchonetClient
           }
         }
 
-        responseTCS.SetResult((value.Message.ESV == ESV.SetGetResponse, opcSetList, opcGetList));
+        responseTCS.SetResult((value.Message.ESV == ESV.SetGetResponse, propsForSet, propsForGet));
 
         // TODO 一斉通知の応答の扱いが…
       }
@@ -644,8 +644,8 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.SetGet,
-        opcListOrOpcSetList: propertiesSet.Select(ConvertToPropertyRequest),
-        opcGetList: propertiesGet.Select(ConvertToPropertyRequestExceptValueData)
+        propsForSetOrGet: propertiesSet.Select(ConvertToPropertyRequest),
+        propsForGet: propertiesGet.Select(ConvertToPropertyRequestExceptValueData)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -707,7 +707,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.InfRequest,
-        opcListOrOpcSetList: properties.Select(ConvertToPropertyRequestExceptValueData)
+        propsForSetOrGet: properties.Select(ConvertToPropertyRequestExceptValueData)
       ),
       cancellationToken
     );
@@ -758,7 +758,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.Inf,
-        opcListOrOpcSetList: properties.Select(ConvertToPropertyRequest)
+        propsForSetOrGet: properties.Select(ConvertToPropertyRequest)
       ),
       cancellationToken
     );
@@ -839,7 +839,7 @@ partial class EchonetClient
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.InfC,
-        opcListOrOpcSetList: properties.Select(ConvertToPropertyRequest)
+        propsForSetOrGet: properties.Select(ConvertToPropertyRequest)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -1180,27 +1180,27 @@ partial class EchonetClient
     }
 
     var hasError = false;
-    var requestOPCList = message.GetOPCList();
-    var responseOPCList = new List<PropertyRequest>(capacity: requestOPCList.Count);
+    var requestProps = message.GetOPCList();
+    var responseProps = new List<PropertyRequest>(capacity: requestProps.Count);
 
-    foreach (var opc in requestOPCList) {
-      var property = destObject.SetProperties.FirstOrDefault(p => p.Spec.Code == opc.EPC);
+    foreach (var prop in requestProps) {
+      var property = destObject.SetProperties.FirstOrDefault(p => p.Spec.Code == prop.EPC);
 
       if (
         property is null ||
-        opc.EDT.Length > property.Spec.MaxSize ||
-        opc.EDT.Length < property.Spec.MinSize
+        prop.EDT.Length > property.Spec.MaxSize ||
+        prop.EDT.Length < property.Spec.MinSize
       ) {
         hasError = true;
         // 要求を受理しなかったEPCに対しては、それに続く PDC に要求時と同じ値を設定し、
         // 要求された EDT を付け、要求を受理できなかったことを示す。
-        responseOPCList.Add(opc);
+        responseProps.Add(prop);
       }
       else {
         // 要求を受理した EPC に対しては、それに続くPDCに0を設定してEDTは付けない
-        property.SetValue(opc.EDT);
+        property.SetValue(prop.EDT);
 
-        responseOPCList.Add(new(opc.EPC));
+        responseProps.Add(new(prop.EPC));
       }
     }
 
@@ -1213,7 +1213,7 @@ partial class EchonetClient
           sourceObject: message.DEOJ, // 入れ替え
           destinationObject: message.SEOJ, // 入れ替え
           esv: ESV.SetIServiceNotAvailable, // SetI_SNA(0x50)
-          opcListOrOpcSetList: responseOPCList
+          propsForSetOrGet: responseProps
         ),
         cancellationToken: default
       ).ConfigureAwait(false);
@@ -1251,33 +1251,33 @@ partial class EchonetClient
   )
   {
     var hasError = false;
-    var requestOPCList = message.GetOPCList();
-    var responseOPCList = new List<PropertyRequest>(capacity: requestOPCList.Count);
+    var requestProps = message.GetOPCList();
+    var responseProps = new List<PropertyRequest>(capacity: requestProps.Count);
 
     if (destObject is null) {
-      // DEOJがない場合、全OPCをそのまま返す
+      // DEOJがない場合、全処理対象プロパティをそのまま返す
       hasError = true;
-      responseOPCList.AddRange(requestOPCList);
+      responseProps.AddRange(requestProps);
     }
     else {
-      foreach (var opc in requestOPCList) {
-        var property = destObject.SetProperties.FirstOrDefault(p => p.Spec.Code == opc.EPC);
+      foreach (var prop in requestProps) {
+        var property = destObject.SetProperties.FirstOrDefault(p => p.Spec.Code == prop.EPC);
 
         if (
           property is null ||
-          opc.EDT.Length > property.Spec.MaxSize ||
-          opc.EDT.Length < property.Spec.MinSize
+          prop.EDT.Length > property.Spec.MaxSize ||
+          prop.EDT.Length < property.Spec.MinSize
         ) {
           hasError = true;
           // 要求を受理しなかったEPCに対しては、それに続く PDC に要求時と同じ値を設定し、
           // 要求された EDT を付け、要求を受理できなかったことを示す。
-          responseOPCList.Add(opc);
+          responseProps.Add(prop);
         }
         else {
           // 要求を受理した EPC に対しては、それに続くPDCに0を設定してEDTは付けない
-          property.SetValue(opc.EDT);
+          property.SetValue(prop.EDT);
 
-          responseOPCList.Add(new(opc.EPC));
+          responseProps.Add(new(prop.EPC));
         }
       }
     }
@@ -1291,7 +1291,7 @@ partial class EchonetClient
           sourceObject: message.DEOJ, // 入れ替え
           destinationObject: message.SEOJ, // 入れ替え
           esv: ESV.SetCServiceNotAvailable, // SetC_SNA(0x51)
-          opcListOrOpcSetList: responseOPCList
+          propsForSetOrGet: responseProps
         ),
         cancellationToken: default
       ).ConfigureAwait(false);
@@ -1307,7 +1307,7 @@ partial class EchonetClient
         sourceObject: message.DEOJ, // 入れ替え
         destinationObject: message.SEOJ, // 入れ替え
         esv: ESV.SetResponse, // Set_Res(0x71)
-        opcListOrOpcSetList: responseOPCList
+        propsForSetOrGet: responseProps
       ),
       cancellationToken: default
     ).ConfigureAwait(false);
@@ -1342,33 +1342,33 @@ partial class EchonetClient
   )
   {
     var hasError = false;
-    var requestOPCList = message.GetOPCList();
-    var responseOPCList = new List<PropertyRequest>(capacity: requestOPCList.Count);
+    var requestProps = message.GetOPCList();
+    var responseProps = new List<PropertyRequest>(capacity: requestProps.Count);
 
     if (destObject is null) {
-      // DEOJがない場合、全OPCをそのまま返す
+      // DEOJがない場合、全処理対象プロパティをそのまま返す
       hasError = true;
-      responseOPCList.AddRange(requestOPCList);
+      responseProps.AddRange(requestProps);
     }
     else {
-      foreach (var opc in requestOPCList) {
-        var property = destObject.SetProperties.FirstOrDefault(p => p.Spec.Code == opc.EPC);
+      foreach (var prop in requestProps) {
+        var property = destObject.SetProperties.FirstOrDefault(p => p.Spec.Code == prop.EPC);
 
         if (
           property is null ||
-          opc.EDT.Length > property.Spec.MaxSize ||
-          opc.EDT.Length < property.Spec.MinSize
+          prop.EDT.Length > property.Spec.MaxSize ||
+          prop.EDT.Length < property.Spec.MinSize
         ) {
           hasError = true;
           // 要求を受理しなかった EPC に対しては、それに続く PDC に 0 を設定して
           // EDT はつけず、要求を受理できなかったことを示す。
           // (そのままでよい)
-          responseOPCList.Add(opc);
+          responseProps.Add(prop);
         }
         else {
           // 要求を受理した EPCに対しては、それに続く PDC に読み出したプロパティの長さを、
           // EDT には読み出したプロパティ値を設定する
-          responseOPCList.Add(new(opc.EPC, property.ValueMemory));
+          responseProps.Add(new(prop.EPC, property.ValueMemory));
         }
       }
     }
@@ -1382,7 +1382,7 @@ partial class EchonetClient
           sourceObject: message.DEOJ, // 入れ替え
           destinationObject: message.SEOJ, // 入れ替え
           esv: ESV.GetServiceNotAvailable, // Get_SNA(0x52)
-          opcListOrOpcSetList: responseOPCList
+          propsForSetOrGet: responseProps
         ),
         cancellationToken: default
       ).ConfigureAwait(false);
@@ -1398,7 +1398,7 @@ partial class EchonetClient
         sourceObject: message.DEOJ, // 入れ替え
         destinationObject: message.SEOJ, // 入れ替え
         esv: ESV.GetResponse, // Get_Res(0x72)
-        opcListOrOpcSetList: responseOPCList
+        propsForSetOrGet: responseProps
       ),
       cancellationToken: default
     ).ConfigureAwait(false);
@@ -1436,56 +1436,56 @@ partial class EchonetClient
   )
   {
     var hasError = false;
-    var (requestOPCSetList, requestOPCGetList) = message.GetOPCSetGetList();
-    var responseOPCSetList = new List<PropertyRequest>(capacity: requestOPCSetList.Count);
-    var responseOPCGetList = new List<PropertyRequest>(capacity: requestOPCGetList.Count);
+    var (requestPropsForSet, requestPropsForGet) = message.GetOPCSetGetList();
+    var responsePropsForSet = new List<PropertyRequest>(capacity: requestPropsForSet.Count);
+    var responsePropsForGet = new List<PropertyRequest>(capacity: requestPropsForGet.Count);
 
     if (destObject is null) {
-      // DEOJがない場合、全OPCをそのまま返す
+      // DEOJがない場合、全処理対象プロパティをそのまま返す
       hasError = true;
-      responseOPCSetList.AddRange(requestOPCSetList);
-      responseOPCGetList.AddRange(requestOPCGetList);
+      responsePropsForSet.AddRange(requestPropsForSet);
+      responsePropsForGet.AddRange(requestPropsForGet);
     }
     else {
-      foreach (var opc in requestOPCSetList) {
-        var property = destObject.SetProperties.FirstOrDefault(p => p.Spec.Code == opc.EPC);
+      foreach (var prop in requestPropsForSet) {
+        var property = destObject.SetProperties.FirstOrDefault(p => p.Spec.Code == prop.EPC);
 
         if (
           property is null ||
-          opc.EDT.Length > property.Spec.MaxSize ||
-          opc.EDT.Length < property.Spec.MinSize
+          prop.EDT.Length > property.Spec.MaxSize ||
+          prop.EDT.Length < property.Spec.MinSize
         ) {
           hasError = true;
           // 要求を受理しなかったEPCに対しては、それに続く PDC に要求時と同じ値を設定し、
           // 要求された EDT を付け、要求を受理できなかったことを示す。
-          responseOPCSetList.Add(opc);
+          responsePropsForSet.Add(prop);
         }
         else {
           // 要求を受理した EPC に対しては、それに続くPDCに0を設定してEDTは付けない
-          property.SetValue(opc.EDT);
+          property.SetValue(prop.EDT);
 
-          responseOPCSetList.Add(new(opc.EPC));
+          responsePropsForSet.Add(new(prop.EPC));
         }
       }
 
-      foreach (var opc in requestOPCGetList) {
-        var property = destObject.SetProperties.FirstOrDefault(p => p.Spec.Code == opc.EPC);
+      foreach (var prop in requestPropsForGet) {
+        var property = destObject.SetProperties.FirstOrDefault(p => p.Spec.Code == prop.EPC);
 
         if (
           property is null ||
-          opc.EDT.Length > property.Spec.MaxSize ||
-          opc.EDT.Length < property.Spec.MinSize
+          prop.EDT.Length > property.Spec.MaxSize ||
+          prop.EDT.Length < property.Spec.MinSize
         ) {
           hasError = true;
           // 要求を受理しなかった EPC に対しては、それに続く PDC に 0 を設定して
           // EDT はつけず、要求を受理できなかったことを示す。
           // (そのままでよい)
-          responseOPCGetList.Add(opc);
+          responsePropsForGet.Add(prop);
         }
         else {
           // 要求を受理した EPCに対しては、それに続く PDC に読み出したプロパティの長さを、
           // EDT には読み出したプロパティ値を設定する
-          responseOPCGetList.Add(new(opc.EPC, property.ValueMemory));
+          responsePropsForGet.Add(new(prop.EPC, property.ValueMemory));
         }
       }
     }
@@ -1499,8 +1499,8 @@ partial class EchonetClient
           sourceObject: message.DEOJ, // 入れ替え
           destinationObject: message.SEOJ, // 入れ替え
           esv: ESV.SetGetServiceNotAvailable, // SetGet_SNA(0x5E)
-          opcListOrOpcSetList: responseOPCSetList,
-          opcGetList: responseOPCGetList
+          propsForSetOrGet: responsePropsForSet,
+          propsForGet: responsePropsForGet
         ),
         cancellationToken: default
       ).ConfigureAwait(false);
@@ -1516,8 +1516,8 @@ partial class EchonetClient
         sourceObject: message.DEOJ, // 入れ替え
         destinationObject: message.SEOJ, // 入れ替え
         esv: ESV.SetGetResponse, // SetGet_Res(0x7E)
-        opcListOrOpcSetList: responseOPCSetList,
-        opcGetList: responseOPCGetList
+        propsForSetOrGet: responsePropsForSet,
+        propsForGet: responsePropsForGet
       ),
       cancellationToken: default
     ).ConfigureAwait(false);
@@ -1557,7 +1557,7 @@ partial class EchonetClient
 #pragma warning restore IDE0060
   {
     var hasError = false;
-    var requestOPCList = message.GetOPCList();
+    var requestProps = message.GetOPCList();
     var sourceObject = sourceNode.Devices.FirstOrDefault(d => d.EOJ == message.SEOJ);
 
     if (sourceObject is null) {
@@ -1573,29 +1573,29 @@ partial class EchonetClient
       }
     }
 
-    foreach (var opc in requestOPCList) {
-      var property = sourceObject.Properties.FirstOrDefault(p => p.Spec.Code == opc.EPC);
+    foreach (var prop in requestProps) {
+      var property = sourceObject.Properties.FirstOrDefault(p => p.Spec.Code == prop.EPC);
 
       if (property is null) {
         // 未知のプロパティ
         // 新規作成
-        property = new(message.SEOJ.ClassGroupCode, message.SEOJ.ClassCode, opc.EPC);
+        property = new(message.SEOJ.ClassGroupCode, message.SEOJ.ClassCode, prop.EPC);
         sourceObject.AddProperty(property);
       }
 
       if (
-        opc.EDT.Length > property.Spec.MaxSize ||
-        opc.EDT.Length < property.Spec.MinSize
+        prop.EDT.Length > property.Spec.MaxSize ||
+        prop.EDT.Length < property.Spec.MinSize
       ) {
         // スペック外なので、格納しない
         hasError = true;
       }
       else {
-        property.SetValue(opc.EDT);
+        property.SetValue(prop.EDT);
 
         // ノードプロファイルのインスタンスリスト通知の場合
-        if (sourceNode.NodeProfile == sourceObject && opc.EPC == 0xD5)
-          await HandleInstanceListNotificationReceivedAsync(sourceNode, opc.EDT).ConfigureAwait(false);
+        if (sourceNode.NodeProfile == sourceObject && prop.EPC == 0xD5)
+          await HandleInstanceListNotificationReceivedAsync(sourceNode, prop.EDT).ConfigureAwait(false);
       }
     }
 
@@ -1631,8 +1631,8 @@ partial class EchonetClient
   )
   {
     var hasError = false;
-    var requestOPCList = message.GetOPCList();
-    var responseOPCList = new List<PropertyRequest>(capacity: requestOPCList.Count);
+    var requestProps = message.GetOPCList();
+    var responseProps = new List<PropertyRequest>(capacity: requestProps.Count);
 
     if (destObject is null) {
       // 指定された DEOJ が存在しない場合には電文を廃棄する。
@@ -1655,34 +1655,34 @@ partial class EchonetClient
       }
     }
 
-    foreach (var opc in requestOPCList) {
-      var property = sourceObject.Properties.FirstOrDefault(p => p.Spec.Code == opc.EPC);
+    foreach (var prop in requestProps) {
+      var property = sourceObject.Properties.FirstOrDefault(p => p.Spec.Code == prop.EPC);
 
       if (property is null) {
         // 未知のプロパティ
         // 新規作成
-        property = new(message.SEOJ.ClassGroupCode, message.SEOJ.ClassCode, opc.EPC);
+        property = new(message.SEOJ.ClassGroupCode, message.SEOJ.ClassCode, prop.EPC);
         sourceObject.AddProperty(property);
       }
 
       if (
-        (property.Spec.MaxSize != null && opc.EDT.Length > property.Spec.MaxSize) ||
-        (property.Spec.MinSize != null && opc.EDT.Length < property.Spec.MinSize)
+        (property.Spec.MaxSize != null && prop.EDT.Length > property.Spec.MaxSize) ||
+        (property.Spec.MinSize != null && prop.EDT.Length < property.Spec.MinSize)
       ) {
         // スペック外なので、格納しない
         hasError = true;
       }
       else {
-        property.SetValue(opc.EDT);
+        property.SetValue(prop.EDT);
 
         // ノードプロファイルのインスタンスリスト通知の場合
-        if (sourceNode.NodeProfile == sourceObject && opc.EPC == 0xD5)
-          await HandleInstanceListNotificationReceivedAsync(sourceNode, opc.EDT).ConfigureAwait(false);
+        if (sourceNode.NodeProfile == sourceObject && prop.EPC == 0xD5)
+          await HandleInstanceListNotificationReceivedAsync(sourceNode, prop.EDT).ConfigureAwait(false);
       }
 
       // EPC には通知時と同じプロパティコードを設定するが、
       // 通知を受信したことを示すため、PDCには 0 を設定し、EDT は付けない。
-      responseOPCList.Add(new(opc.EPC));
+      responseProps.Add(new(prop.EPC));
     }
 
     if (destObject is not null) {
@@ -1694,7 +1694,7 @@ partial class EchonetClient
           sourceObject: message.DEOJ, // 入れ替え
           destinationObject: message.SEOJ, // 入れ替え
           esv: ESV.InfCResponse, // INFC_Res(0x74)
-          opcListOrOpcSetList: responseOPCList
+          propsForSetOrGet: responseProps
         ),
         cancellationToken: default
       ).ConfigureAwait(false);

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/Format1Message.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/Format1Message.cs
@@ -72,19 +72,19 @@ public class Format1MessageTests {
   [TestCase(ESV.GetServiceNotAvailable, false)]
   [TestCase(ESV.InfServiceNotAvailable, false)]
   [TestCase(ESV.SetGetServiceNotAvailable, true)]
-  public void GetOPCList(ESV esv, bool expectedAsWriteOrReadService)
+  public void GetProperties(ESV esv, bool expectedAsWriteOrReadService)
   {
     var message = expectedAsWriteOrReadService
       ? new Format1Message(seoj: default, deoj: default, esv: esv, propertiesForSet: Array.Empty<PropertyRequest>(), propertiesForGet: Array.Empty<PropertyRequest>())
       : new Format1Message(seoj: default, deoj: default, esv: esv, properties: Array.Empty<PropertyRequest>());
 
     if (expectedAsWriteOrReadService) {
-      Assert.That(message.GetOPCList, Throws.InvalidOperationException);
+      Assert.That(message.GetProperties, Throws.InvalidOperationException);
     }
     else {
-      Assert.That(message.GetOPCList, Throws.Nothing);
+      Assert.That(message.GetProperties, Throws.Nothing);
 
-      Assert.That(message.GetOPCList(), Is.Not.Null);
+      Assert.That(message.GetProperties(), Is.Not.Null);
     }
   }
 
@@ -104,22 +104,22 @@ public class Format1MessageTests {
   [TestCase(ESV.GetServiceNotAvailable, false)]
   [TestCase(ESV.InfServiceNotAvailable, false)]
   [TestCase(ESV.SetGetServiceNotAvailable, true)]
-  public void GetOPCSetGetList(ESV esv, bool expectedAsWriteOrReadService)
+  public void GetPropertiesForSetAndGet(ESV esv, bool expectedAsWriteOrReadService)
   {
     var message = expectedAsWriteOrReadService
       ? new Format1Message(seoj: default, deoj: default, esv: esv, propertiesForSet: Array.Empty<PropertyRequest>(), propertiesForGet: Array.Empty<PropertyRequest>())
       : new Format1Message(seoj: default, deoj: default, esv: esv, properties: Array.Empty<PropertyRequest>());
 
     if (expectedAsWriteOrReadService) {
-      Assert.That(message.GetOPCSetGetList, Throws.Nothing);
+      Assert.That(message.GetPropertiesForSetAndGet, Throws.Nothing);
 
-      var (propertiesForSet, propertiesForGet) = message.GetOPCSetGetList();
+      var (propertiesForSet, propertiesForGet) = message.GetPropertiesForSetAndGet();
 
       Assert.That(propertiesForSet, Is.Not.Null);
       Assert.That(propertiesForGet, Is.Not.Null);
     }
     else {
-      Assert.That(message.GetOPCSetGetList, Throws.InvalidOperationException);
+      Assert.That(message.GetPropertiesForSetAndGet, Throws.InvalidOperationException);
     }
   }
 

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/Format1Message.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/Format1Message.cs
@@ -15,20 +15,20 @@ public class Format1MessageTests {
   public void Ctor_NotForWriteOrReadService_ESVMismatch(ESV esv)
   {
     Assert.Throws<ArgumentException>(
-      () => new Format1Message(seoj: default, deoj: default, esv: esv, opcList: Array.Empty<PropertyRequest>())
+      () => new Format1Message(seoj: default, deoj: default, esv: esv, properties: Array.Empty<PropertyRequest>())
     );
   }
 
   [TestCase(ESV.SetGet)]
   [TestCase(ESV.SetGetResponse)]
   [TestCase(ESV.SetGetServiceNotAvailable)]
-  public void Ctor_ForWriteOrReadService_OPCSetOPCGetCanNotBeNull(ESV esv)
+  public void Ctor_ForWriteOrReadService_BothPropsForSetAndPropsForGetCanNotBeNull(ESV esv)
   {
     Assert.Throws<ArgumentNullException>(
-      () => new Format1Message(seoj: default, deoj: default, esv: esv, opcSetList: null!, opcGetList: Array.Empty<PropertyRequest>())
+      () => new Format1Message(seoj: default, deoj: default, esv: esv, propertiesForSet: null!, propertiesForGet: Array.Empty<PropertyRequest>())
     );
     Assert.Throws<ArgumentNullException>(
-      () => new Format1Message(seoj: default, deoj: default, esv: esv, opcSetList: Array.Empty<PropertyRequest>(), opcGetList: null!)
+      () => new Format1Message(seoj: default, deoj: default, esv: esv, propertiesForSet: Array.Empty<PropertyRequest>(), propertiesForGet: null!)
     );
   }
 
@@ -40,7 +40,7 @@ public class Format1MessageTests {
   public void Ctor_ForWriteOrReadService_ESVMismatch(ESV esv)
   {
     Assert.Throws<ArgumentException>(
-      () => new Format1Message(seoj: default, deoj: default, esv: esv, opcSetList: Array.Empty<PropertyRequest>(), opcGetList: Array.Empty<PropertyRequest>())
+      () => new Format1Message(seoj: default, deoj: default, esv: esv, propertiesForSet: Array.Empty<PropertyRequest>(), propertiesForGet: Array.Empty<PropertyRequest>())
     );
   }
 
@@ -49,10 +49,10 @@ public class Format1MessageTests {
   [TestCase(ESV.Inf)]
   [TestCase(ESV.SetIServiceNotAvailable)]
   [TestCase(ESV.GetServiceNotAvailable)]
-  public void Ctor_NotForWriteOrReadService_OPCanNotBeNull(ESV esv)
+  public void Ctor_NotForWriteOrReadService_PropsCanNotBeNull(ESV esv)
   {
     Assert.Throws<ArgumentNullException>(
-      () => new Format1Message(seoj: default, deoj: default, esv: esv, opcList: null!)
+      () => new Format1Message(seoj: default, deoj: default, esv: esv, properties: null!)
     );
   }
 
@@ -75,8 +75,8 @@ public class Format1MessageTests {
   public void GetOPCList(ESV esv, bool expectedAsWriteOrReadService)
   {
     var message = expectedAsWriteOrReadService
-      ? new Format1Message(seoj: default, deoj: default, esv: esv, opcSetList: Array.Empty<PropertyRequest>(), opcGetList: Array.Empty<PropertyRequest>())
-      : new Format1Message(seoj: default, deoj: default, esv: esv, opcList: Array.Empty<PropertyRequest>());
+      ? new Format1Message(seoj: default, deoj: default, esv: esv, propertiesForSet: Array.Empty<PropertyRequest>(), propertiesForGet: Array.Empty<PropertyRequest>())
+      : new Format1Message(seoj: default, deoj: default, esv: esv, properties: Array.Empty<PropertyRequest>());
 
     if (expectedAsWriteOrReadService) {
       Assert.That(message.GetOPCList, Throws.InvalidOperationException);
@@ -107,16 +107,16 @@ public class Format1MessageTests {
   public void GetOPCSetGetList(ESV esv, bool expectedAsWriteOrReadService)
   {
     var message = expectedAsWriteOrReadService
-      ? new Format1Message(seoj: default, deoj: default, esv: esv, opcSetList: Array.Empty<PropertyRequest>(), opcGetList: Array.Empty<PropertyRequest>())
-      : new Format1Message(seoj: default, deoj: default, esv: esv, opcList: Array.Empty<PropertyRequest>());
+      ? new Format1Message(seoj: default, deoj: default, esv: esv, propertiesForSet: Array.Empty<PropertyRequest>(), propertiesForGet: Array.Empty<PropertyRequest>())
+      : new Format1Message(seoj: default, deoj: default, esv: esv, properties: Array.Empty<PropertyRequest>());
 
     if (expectedAsWriteOrReadService) {
       Assert.That(message.GetOPCSetGetList, Throws.Nothing);
 
-      var (opcSetList, opcGetList) = message.GetOPCSetGetList();
+      var (propertiesForSet, propertiesForGet) = message.GetOPCSetGetList();
 
-      Assert.That(opcSetList, Is.Not.Null);
-      Assert.That(opcGetList, Is.Not.Null);
+      Assert.That(propertiesForSet, Is.Not.Null);
+      Assert.That(propertiesForGet, Is.Not.Null);
     }
     else {
       Assert.That(message.GetOPCSetGetList, Throws.InvalidOperationException);

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Deserialize.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Deserialize.cs
@@ -245,9 +245,9 @@ partial class FrameSerializerTests {
 
     Assert.That(FrameSerializer.TryParseEDataAsFormat1Message(input, out var edata), Is.True);
 
-    Assert.That(edata.GetOPCList, Throws.InvalidOperationException);
+    Assert.That(edata.GetProperties, Throws.InvalidOperationException);
 
-    var (propsForSet, propsForGet) = edata.GetOPCSetGetList();
+    var (propsForSet, propsForGet) = edata.GetPropertiesForSetAndGet();
 
     Assert.That(propsForSet, Is.Not.Null, nameof(propsForSet));
     Assert.That(propsForSet.Count, Is.EqualTo(2), "Properties for set");
@@ -295,9 +295,9 @@ partial class FrameSerializerTests {
 
     Assert.That(FrameSerializer.TryParseEDataAsFormat1Message(input, out var edata), Is.True);
 
-    Assert.That(edata.GetOPCSetGetList, Throws.InvalidOperationException);
+    Assert.That(edata.GetPropertiesForSetAndGet, Throws.InvalidOperationException);
 
-    var props = edata.GetOPCList();
+    var props = edata.GetProperties();
 
     Assert.That(props, Is.Not.Null, nameof(props));
     Assert.That(props.Count, Is.EqualTo(2), "Properties");
@@ -329,9 +329,9 @@ partial class FrameSerializerTests {
 
     Assert.That(FrameSerializer.TryParseEDataAsFormat1Message(input, out var edata), Is.True);
 
-    Assert.That(edata.GetOPCList, Throws.InvalidOperationException);
+    Assert.That(edata.GetProperties, Throws.InvalidOperationException);
 
-    var (propsForSet, propsForGet) = edata.GetOPCSetGetList();
+    var (propsForSet, propsForGet) = edata.GetPropertiesForSetAndGet();
 
     Assert.That(propsForSet, Is.Not.Null, nameof(propsForSet));
     Assert.That(propsForSet, Is.Empty, nameof(propsForSet));
@@ -360,9 +360,9 @@ partial class FrameSerializerTests {
 
     Assert.That(FrameSerializer.TryParseEDataAsFormat1Message(input, out var edata), Is.True);
 
-    Assert.That(edata.GetOPCList, Throws.InvalidOperationException);
+    Assert.That(edata.GetProperties, Throws.InvalidOperationException);
 
-    var (propsForSet, propsForGet) = edata.GetOPCSetGetList();
+    var (propsForSet, propsForGet) = edata.GetPropertiesForSetAndGet();
 
     Assert.That(propsForSet, Is.Not.Null, nameof(propsForSet));
     Assert.That(propsForSet.Count, Is.EqualTo(1), "Properties for set");

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Deserialize.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Deserialize.cs
@@ -217,7 +217,7 @@ partial class FrameSerializerTests {
   [TestCase(ESV.SetGet)]
   [TestCase(ESV.SetGetResponse)]
   [TestCase(ESV.SetGetServiceNotAvailable)]
-  public void TryParseEDataAsFormat1Message_OPC_OfESVSetGet(ESV esv)
+  public void TryParseEDataAsFormat1Message_Properties_OfESVSetGet(ESV esv)
   {
     var input = CreateEDATAFormat1(
       (byte)esv,
@@ -247,39 +247,39 @@ partial class FrameSerializerTests {
 
     Assert.That(edata.GetOPCList, Throws.InvalidOperationException);
 
-    var (opcSetList, opcGetList) = edata.GetOPCSetGetList();
+    var (propsForSet, propsForGet) = edata.GetOPCSetGetList();
 
-    Assert.That(opcSetList, Is.Not.Null, nameof(opcSetList));
-    Assert.That(opcSetList.Count, Is.EqualTo(2), "OPCSet");
+    Assert.That(propsForSet, Is.Not.Null, nameof(propsForSet));
+    Assert.That(propsForSet.Count, Is.EqualTo(2), "Properties for set");
 
-    var opcSetArray = opcSetList.ToArray();
+    var propsArrayForSet = propsForSet.ToArray();
 
-    Assert.That(opcSetArray[0].EPC, Is.EqualTo(0x10), "OPCSet #1 EPC");
-    Assert.That(opcSetArray[0].PDC, Is.EqualTo(1), "OPCSet #1 PDC");
-    Assert.That(opcSetArray[0].EDT, SequenceIs.EqualTo(new byte[] { 0x11 }), "OPCSet #1 EDT");
+    Assert.That(propsArrayForSet[0].EPC, Is.EqualTo(0x10), "Properties for set #1 EPC");
+    Assert.That(propsArrayForSet[0].PDC, Is.EqualTo(1), "Properties for set #1 PDC");
+    Assert.That(propsArrayForSet[0].EDT, SequenceIs.EqualTo(new byte[] { 0x11 }), "Properties for set #1 EDT");
 
-    Assert.That(opcSetArray[1].EPC, Is.EqualTo(0x20), "OPCSet #2 EPC");
-    Assert.That(opcSetArray[1].PDC, Is.EqualTo(2), "OPCSet #2 PDC");
-    Assert.That(opcSetArray[1].EDT, SequenceIs.EqualTo(new byte[] { 0x21, 0x22 }), "OPCSet #2 EDT");
+    Assert.That(propsArrayForSet[1].EPC, Is.EqualTo(0x20), "Properties for set #2 EPC");
+    Assert.That(propsArrayForSet[1].PDC, Is.EqualTo(2), "Properties for set #2 PDC");
+    Assert.That(propsArrayForSet[1].EDT, SequenceIs.EqualTo(new byte[] { 0x21, 0x22 }), "Properties for set #2 EDT");
 
-    Assert.That(opcGetList, Is.Not.Null, nameof(opcSetList));
-    Assert.That(opcSetList.Count, Is.EqualTo(2), "OPCGet");
+    Assert.That(propsForGet, Is.Not.Null, nameof(propsForSet));
+    Assert.That(propsForSet.Count, Is.EqualTo(2), "Properties for get");
 
-    var opcGetArray = opcGetList.ToArray();
+    var propsArrayForGet = propsForGet.ToArray();
 
-    Assert.That(opcGetArray[0].EPC, Is.EqualTo(0x30), "OPCGet #1 EPC");
-    Assert.That(opcGetArray[0].PDC, Is.EqualTo(3), "OPCGet #1 PDC");
-    Assert.That(opcGetArray[0].EDT, SequenceIs.EqualTo(new byte[] { 0x31, 0x32, 0x33 }), "OPCGet #1 EDT");
+    Assert.That(propsArrayForGet[0].EPC, Is.EqualTo(0x30), "Properties for get #1 EPC");
+    Assert.That(propsArrayForGet[0].PDC, Is.EqualTo(3), "Properties for get #1 PDC");
+    Assert.That(propsArrayForGet[0].EDT, SequenceIs.EqualTo(new byte[] { 0x31, 0x32, 0x33 }), "Properties for get #1 EDT");
 
-    Assert.That(opcGetArray[1].EPC, Is.EqualTo(0x40), "OPCGet #2 EPC");
-    Assert.That(opcGetArray[1].PDC, Is.EqualTo(4), "OPCGet #2 PDC");
-    Assert.That(opcGetArray[1].EDT, SequenceIs.EqualTo(new byte[] { 0x41, 0x42, 0x43, 0x44 }), "OPCGet #2 EDT");
+    Assert.That(propsArrayForGet[1].EPC, Is.EqualTo(0x40), "Properties for get #2 EPC");
+    Assert.That(propsArrayForGet[1].PDC, Is.EqualTo(4), "Properties for get #2 PDC");
+    Assert.That(propsArrayForGet[1].EDT, SequenceIs.EqualTo(new byte[] { 0x41, 0x42, 0x43, 0x44 }), "Properties for get #2 EDT");
   }
 
   [TestCase(ESV.Get)]
   [TestCase(ESV.SetI)]
   [TestCase(ESV.Inf)]
-  public void TryParseEDataAsFormat1Message_OPC_OfESVOtherThanSetGet(ESV esv)
+  public void TryParseEDataAsFormat1Message_Properties_OfESVOtherThanSetGet(ESV esv)
   {
     var input = CreateEDATAFormat1(
       (byte)esv,
@@ -297,20 +297,20 @@ partial class FrameSerializerTests {
 
     Assert.That(edata.GetOPCSetGetList, Throws.InvalidOperationException);
 
-    var opcList = edata.GetOPCList();
+    var props = edata.GetOPCList();
 
-    Assert.That(opcList, Is.Not.Null, nameof(opcList));
-    Assert.That(opcList.Count, Is.EqualTo(2), "OPC");
+    Assert.That(props, Is.Not.Null, nameof(props));
+    Assert.That(props.Count, Is.EqualTo(2), "Properties");
 
-    var opcArray = opcList.ToArray();
+    var propsArray = props.ToArray();
 
-    Assert.That(opcArray[0].EPC, Is.EqualTo(0x10), "OPC #1 EPC");
-    Assert.That(opcArray[0].PDC, Is.EqualTo(1), "OPC #1 PDC");
-    Assert.That(opcArray[0].EDT, SequenceIs.EqualTo(new byte[] { 0x11 }), "OPC #1 EDT");
+    Assert.That(propsArray[0].EPC, Is.EqualTo(0x10), "Properties #1 EPC");
+    Assert.That(propsArray[0].PDC, Is.EqualTo(1), "Properties #1 PDC");
+    Assert.That(propsArray[0].EDT, SequenceIs.EqualTo(new byte[] { 0x11 }), "Properties #1 EDT");
 
-    Assert.That(opcArray[1].EPC, Is.EqualTo(0x20), "OPC #2 EPC");
-    Assert.That(opcArray[1].PDC, Is.EqualTo(2), "OPC #2 PDC");
-    Assert.That(opcArray[1].EDT, SequenceIs.EqualTo(new byte[] { 0x21, 0x22 }), "OPC #2 EDT");
+    Assert.That(propsArray[1].EPC, Is.EqualTo(0x20), "Properties #2 EPC");
+    Assert.That(propsArray[1].PDC, Is.EqualTo(2), "Properties #2 PDC");
+    Assert.That(propsArray[1].EDT, SequenceIs.EqualTo(new byte[] { 0x21, 0x22 }), "Properties #2 EDT");
   }
 
   [Test]
@@ -331,19 +331,19 @@ partial class FrameSerializerTests {
 
     Assert.That(edata.GetOPCList, Throws.InvalidOperationException);
 
-    var (opcSetList, opcGetList) = edata.GetOPCSetGetList();
+    var (propsForSet, propsForGet) = edata.GetOPCSetGetList();
 
-    Assert.That(opcSetList, Is.Not.Null, nameof(opcSetList));
-    Assert.That(opcSetList, Is.Empty, nameof(opcSetList));
+    Assert.That(propsForSet, Is.Not.Null, nameof(propsForSet));
+    Assert.That(propsForSet, Is.Empty, nameof(propsForSet));
 
-    Assert.That(opcGetList, Is.Not.Null, nameof(opcGetList));
-    Assert.That(opcGetList.Count, Is.EqualTo(1), "OPCGet");
+    Assert.That(propsForGet, Is.Not.Null, nameof(propsForGet));
+    Assert.That(propsForGet.Count, Is.EqualTo(1), "Properties for get");
 
-    var opcGetArray = opcGetList.ToArray();
+    var propsArrayForGet = propsForGet.ToArray();
 
-    Assert.That(opcGetArray[0].EPC, Is.EqualTo(0x30), "OPCGet #1 EPC");
-    Assert.That(opcGetArray[0].PDC, Is.EqualTo(3), "OPCGet #1 PDC");
-    Assert.That(opcGetArray[0].EDT, SequenceIs.EqualTo(new byte[] { 0x31, 0x32, 0x33 }), "OPCGet #1 EDT");
+    Assert.That(propsArrayForGet[0].EPC, Is.EqualTo(0x30), "Properties for get #1 EPC");
+    Assert.That(propsArrayForGet[0].PDC, Is.EqualTo(3), "Properties for get #1 PDC");
+    Assert.That(propsArrayForGet[0].EDT, SequenceIs.EqualTo(new byte[] { 0x31, 0x32, 0x33 }), "Properties for get #1 EDT");
   }
 
   [Test]
@@ -362,18 +362,18 @@ partial class FrameSerializerTests {
 
     Assert.That(edata.GetOPCList, Throws.InvalidOperationException);
 
-    var (opcSetList, opcGetList) = edata.GetOPCSetGetList();
+    var (propsForSet, propsForGet) = edata.GetOPCSetGetList();
 
-    Assert.That(opcSetList, Is.Not.Null, nameof(opcSetList));
-    Assert.That(opcSetList.Count, Is.EqualTo(1), "OPCSet");
+    Assert.That(propsForSet, Is.Not.Null, nameof(propsForSet));
+    Assert.That(propsForSet.Count, Is.EqualTo(1), "Properties for set");
 
-    var opcSetArray = opcSetList.ToArray();
+    var propsArrayForSet = propsForSet.ToArray();
 
-    Assert.That(opcSetArray[0].EPC, Is.EqualTo(0x10), "OPCSet #1 EPC");
-    Assert.That(opcSetArray[0].PDC, Is.EqualTo(1), "OPCSet #1 PDC");
-    Assert.That(opcSetArray[0].EDT, SequenceIs.EqualTo(new byte[] { 0x11 }), "OPCSet #1 EDT");
+    Assert.That(propsArrayForSet[0].EPC, Is.EqualTo(0x10), "Properties for set #1 EPC");
+    Assert.That(propsArrayForSet[0].PDC, Is.EqualTo(1), "Properties for set #1 PDC");
+    Assert.That(propsArrayForSet[0].EDT, SequenceIs.EqualTo(new byte[] { 0x11 }), "Properties for set #1 EDT");
 
-    Assert.That(opcGetList, Is.Not.Null, nameof(opcGetList));
-    Assert.That(opcGetList, Is.Empty, nameof(opcGetList));
+    Assert.That(propsForGet, Is.Not.Null, nameof(propsForGet));
+    Assert.That(propsForGet, Is.Empty, nameof(propsForGet));
   }
 }

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Serialize.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Serialize.cs
@@ -31,15 +31,15 @@ partial class FrameSerializerTests {
         sourceObject: default,
         destinationObject: default,
         esv: default,
-        opcListOrOpcSetList: Array.Empty<PropertyRequest>(),
-        opcGetList: Array.Empty<PropertyRequest>()
+        propsForSetOrGet: Array.Empty<PropertyRequest>(),
+        propsForGet: Array.Empty<PropertyRequest>()
       ),
       message: "buffer null"
     );
   }
 
   [Test]
-  public void SerializeEchonetLiteFrameFormat1_ArgumentNull_OPCList()
+  public void SerializeEchonetLiteFrameFormat1_ArgumentNull_Properties()
   {
     Assert.Throws<ArgumentNullException>(
       () => FrameSerializer.SerializeEchonetLiteFrameFormat1(
@@ -48,10 +48,10 @@ partial class FrameSerializerTests {
         sourceObject: default,
         destinationObject: default,
         esv: default,
-        opcListOrOpcSetList: null!,
-        opcGetList: null
+        propsForSetOrGet: null!,
+        propsForGet: null
       ),
-      message: "opcListOrOpcSetList null"
+      message: "propsForSetOrGet null"
     );
   }
 
@@ -71,8 +71,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: default,
-      opcListOrOpcSetList: Array.Empty<PropertyRequest>(),
-      opcGetList: Array.Empty<PropertyRequest>()
+      propsForSetOrGet: Array.Empty<PropertyRequest>(),
+      propsForGet: Array.Empty<PropertyRequest>()
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -116,8 +116,8 @@ partial class FrameSerializerTests {
       sourceObject: seoj,
       destinationObject: default,
       esv: default,
-      opcListOrOpcSetList: Array.Empty<PropertyRequest>(),
-      opcGetList: Array.Empty<PropertyRequest>()
+      propsForSetOrGet: Array.Empty<PropertyRequest>(),
+      propsForGet: Array.Empty<PropertyRequest>()
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -146,8 +146,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: deoj,
       esv: default,
-      opcListOrOpcSetList: Array.Empty<PropertyRequest>(),
-      opcGetList: Array.Empty<PropertyRequest>()
+      propsForSetOrGet: Array.Empty<PropertyRequest>(),
+      propsForGet: Array.Empty<PropertyRequest>()
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -188,11 +188,11 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      opcListOrOpcSetList: esv switch {
+      propsForSetOrGet: esv switch {
         ESV.SetGet or ESV.SetGetResponse or ESV.SetGetServiceNotAvailable => [ new() ],
         _ => Array.Empty<PropertyRequest>(),
       },
-      opcGetList: esv switch {
+      propsForGet: esv switch {
         ESV.SetGet or ESV.SetGetResponse or ESV.SetGetServiceNotAvailable => [ new() ],
         _ => Array.Empty<PropertyRequest>(),
       }
@@ -222,7 +222,7 @@ partial class FrameSerializerTests {
   public void SerializeEchonetLiteFrameFormat1_OPC_ForSingleProperty(ESV esv)
   {
     var edt = new byte[] { 0x00, 0x01, 0x02, 0x03 };
-    var opc = new List<PropertyRequest>() {
+    var props = new List<PropertyRequest>() {
       new(
         epc: 0xFF,
         edt: edt
@@ -237,8 +237,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      opcListOrOpcSetList: opc,
-      opcGetList: Array.Empty<PropertyRequest>()
+      propsForSetOrGet: props,
+      propsForGet: Array.Empty<PropertyRequest>()
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -246,26 +246,26 @@ partial class FrameSerializerTests {
     Assert.That(frameBytes[0], Is.EqualTo(0x10), "Frame[0] EHD1");
     Assert.That(frameBytes[1], Is.EqualTo(0x81), "Frame[1] EHD2");
 
-    Assert.That(frameBytes[11], Is.EqualTo(opc.Count), "Frame[11] OPC");
-    Assert.That(frameBytes[12], Is.EqualTo(opc[0].EPC), "Frame[12] OPC#0 EPC");
-    Assert.That(frameBytes[13], Is.EqualTo(opc[0].PDC), "Frame[13] OPC#0 PDC");
-    Assert.That(frameBytes[14..], SequenceIs.EqualTo(opc[0].EDT), "Frame[14..] OPC#0 EDT");
+    Assert.That(frameBytes[11], Is.EqualTo(props.Count), "Frame[11] OPC");
+    Assert.That(frameBytes[12], Is.EqualTo(props[0].EPC), "Frame[12] OPC#0 EPC");
+    Assert.That(frameBytes[13], Is.EqualTo(props[0].PDC), "Frame[13] OPC#0 PDC");
+    Assert.That(frameBytes[14..], SequenceIs.EqualTo(props[0].EDT), "Frame[14..] OPC#0 EDT");
   }
 
   [TestCase(ESV.SetI)]
   [TestCase(ESV.Get)]
   public void SerializeEchonetLiteFrameFormat1_ForMultipleProperty(ESV esv)
   {
-    var opc0edt = new byte[] { 0x10, 0x11 };
-    var opc1edt = new byte[] { 0x20, 0x21, 0x22 };
-    var opc = new List<PropertyRequest>() {
+    var prop0edt = new byte[] { 0x10, 0x11 };
+    var prop1edt = new byte[] { 0x20, 0x21, 0x22 };
+    var props = new List<PropertyRequest>() {
       new(
         epc: 0x10,
-        edt: opc0edt
+        edt: prop0edt
       ),
       new(
         epc: 0x20,
-        edt: opc1edt
+        edt: prop1edt
       ),
     };
 
@@ -277,8 +277,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      opcListOrOpcSetList: opc,
-      opcGetList: Array.Empty<PropertyRequest>()
+      propsForSetOrGet: props,
+      propsForGet: Array.Empty<PropertyRequest>()
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -286,14 +286,14 @@ partial class FrameSerializerTests {
     Assert.That(frameBytes[0], Is.EqualTo(0x10), "Frame[0] EHD1");
     Assert.That(frameBytes[1], Is.EqualTo(0x81), "Frame[1] EHD2");
 
-    Assert.That(frameBytes[11], Is.EqualTo(opc.Count), "Frame[11] OPC");
-    Assert.That(frameBytes[12], Is.EqualTo(opc[0].EPC), "Frame[12] OPC#0 EPC");
-    Assert.That(frameBytes[13], Is.EqualTo(opc[0].PDC), "Frame[13] OPC#0 PDC");
-    Assert.That(frameBytes[14..16], SequenceIs.EqualTo(opc[0].EDT), "Frame[14..16] OPC#0 EDT");
+    Assert.That(frameBytes[11], Is.EqualTo(props.Count), "Frame[11] OPC");
+    Assert.That(frameBytes[12], Is.EqualTo(props[0].EPC), "Frame[12] OPC#0 EPC");
+    Assert.That(frameBytes[13], Is.EqualTo(props[0].PDC), "Frame[13] OPC#0 PDC");
+    Assert.That(frameBytes[14..16], SequenceIs.EqualTo(props[0].EDT), "Frame[14..16] OPC#0 EDT");
 
-    Assert.That(frameBytes[16], Is.EqualTo(opc[1].EPC), "Frame[16] OPC#1 EPC");
-    Assert.That(frameBytes[17], Is.EqualTo(opc[1].PDC), "Frame[17] OPC#1 PDC");
-    Assert.That(frameBytes[18..21], SequenceIs.EqualTo(opc[1].EDT), "Frame[18..21] OPC#1 EDT");
+    Assert.That(frameBytes[16], Is.EqualTo(props[1].EPC), "Frame[16] OPC#1 EPC");
+    Assert.That(frameBytes[17], Is.EqualTo(props[1].PDC), "Frame[17] OPC#1 PDC");
+    Assert.That(frameBytes[18..21], SequenceIs.EqualTo(props[1].EDT), "Frame[18..21] OPC#1 EDT");
   }
 
   [TestCase(ESV.SetGet)]
@@ -301,18 +301,18 @@ partial class FrameSerializerTests {
   [TestCase(ESV.SetGetServiceNotAvailable)]
   public void SerializeEchonetLiteFrameFormat1_OPCGet_OPCSet_ForSingleProperty(ESV esv)
   {
-    var edtOPCSet = new byte[] { 0x00, 0x01, 0x02, 0x03 };
-    var opcSet = new List<PropertyRequest>() {
+    var edtSet = new byte[] { 0x00, 0x01, 0x02, 0x03 };
+    var propsSet = new List<PropertyRequest>() {
       new(
         epc: 0xFE,
-        edt: edtOPCSet
+        edt: edtSet
       ),
     };
-    var edtOPCGet = new byte[] { 0x10, 0x11, 0x12, 0x13, 0x14 };
-    var opcGet = new List<PropertyRequest>() {
+    var edtGet = new byte[] { 0x10, 0x11, 0x12, 0x13, 0x14 };
+    var propsGet = new List<PropertyRequest>() {
       new(
         epc: 0xFF,
-        edt: edtOPCGet
+        edt: edtGet
       ),
     };
 
@@ -324,8 +324,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      opcListOrOpcSetList: opcSet,
-      opcGetList: opcGet
+      propsForSetOrGet: propsSet,
+      propsForGet: propsGet
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -333,15 +333,15 @@ partial class FrameSerializerTests {
     Assert.That(frameBytes[0], Is.EqualTo(0x10), "Frame[0] EHD1");
     Assert.That(frameBytes[1], Is.EqualTo(0x81), "Frame[1] EHD2");
 
-    Assert.That(frameBytes[11], Is.EqualTo(opcSet.Count), "Frame[11] OPCSet");
-    Assert.That(frameBytes[12], Is.EqualTo(opcSet[0].EPC), "Frame[12] OPCSet#0 EPC");
-    Assert.That(frameBytes[13], Is.EqualTo(opcSet[0].PDC), "Frame[13] OPCSet#0 PDC");
-    Assert.That(frameBytes[14..18], SequenceIs.EqualTo(opcSet[0].EDT), "Frame[14..18] OPCSet#0 EDT");
+    Assert.That(frameBytes[11], Is.EqualTo(propsSet.Count), "Frame[11] OPCSet");
+    Assert.That(frameBytes[12], Is.EqualTo(propsSet[0].EPC), "Frame[12] OPCSet#0 EPC");
+    Assert.That(frameBytes[13], Is.EqualTo(propsSet[0].PDC), "Frame[13] OPCSet#0 PDC");
+    Assert.That(frameBytes[14..18], SequenceIs.EqualTo(propsSet[0].EDT), "Frame[14..18] OPCSet#0 EDT");
 
-    Assert.That(frameBytes[18], Is.EqualTo(opcGet.Count), "Frame[18] OPCGet");
-    Assert.That(frameBytes[19], Is.EqualTo(opcGet[0].EPC), "Frame[19] OPCGet#0 EPC");
-    Assert.That(frameBytes[20], Is.EqualTo(opcGet[0].PDC), "Frame[20] OPCGet#0 PDC");
-    Assert.That(frameBytes[21..26], SequenceIs.EqualTo(opcGet[0].EDT), "Frame[21..26] OPCGet#0 EDT");
+    Assert.That(frameBytes[18], Is.EqualTo(propsGet.Count), "Frame[18] OPCGet");
+    Assert.That(frameBytes[19], Is.EqualTo(propsGet[0].EPC), "Frame[19] OPCGet#0 EPC");
+    Assert.That(frameBytes[20], Is.EqualTo(propsGet[0].PDC), "Frame[20] OPCGet#0 PDC");
+    Assert.That(frameBytes[21..26], SequenceIs.EqualTo(propsGet[0].EDT), "Frame[21..26] OPCGet#0 EDT");
   }
 
   [TestCase(ESV.SetGet)]
@@ -349,23 +349,23 @@ partial class FrameSerializerTests {
   [TestCase(ESV.SetGetServiceNotAvailable)]
   public void SerializeEchonetLiteFrameFormat1_OPCSet_ForMultipleProperty(ESV esv)
   {
-    var edtOPCSet0 = new byte[] { 0x11, 0x12 };
-    var edtOPCSet1 = new byte[] { 0x21, 0x22, 0x23 };
-    var opcSet = new List<PropertyRequest>() {
+    var edtSet0 = new byte[] { 0x11, 0x12 };
+    var edtSet1 = new byte[] { 0x21, 0x22, 0x23 };
+    var propsSet = new List<PropertyRequest>() {
       new(
         epc: 0x10,
-        edt: edtOPCSet0
+        edt: edtSet0
       ),
       new(
         epc: 0x20,
-        edt: edtOPCSet1
+        edt: edtSet1
       ),
     };
-    var edtOPCGet = new byte[] { 0x31, 0x32, 0x33, 0x34 };
-    var opcGet = new List<PropertyRequest>() {
+    var edtGet = new byte[] { 0x31, 0x32, 0x33, 0x34 };
+    var propsGet = new List<PropertyRequest>() {
       new(
         epc: 0x30,
-        edt: edtOPCGet
+        edt: edtGet
       ),
     };
 
@@ -377,8 +377,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      opcListOrOpcSetList: opcSet,
-      opcGetList: opcGet
+      propsForSetOrGet: propsSet,
+      propsForGet: propsGet
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -386,18 +386,18 @@ partial class FrameSerializerTests {
     Assert.That(frameBytes[0], Is.EqualTo(0x10), "Frame[0] EHD1");
     Assert.That(frameBytes[1], Is.EqualTo(0x81), "Frame[1] EHD2");
 
-    Assert.That(frameBytes[11], Is.EqualTo(opcSet.Count), "Frame[11] OPCSet");
-    Assert.That(frameBytes[12], Is.EqualTo(opcSet[0].EPC), "Frame[12] OPCSet#0 EPC");
-    Assert.That(frameBytes[13], Is.EqualTo(opcSet[0].PDC), "Frame[13] OPCSet#0 PDC");
-    Assert.That(frameBytes[14..16], SequenceIs.EqualTo(opcSet[0].EDT), "Frame[14..16] OPCSet#0 EDT");
-    Assert.That(frameBytes[16], Is.EqualTo(opcSet[1].EPC), "Frame[16] OPCSet#1 EPC");
-    Assert.That(frameBytes[17], Is.EqualTo(opcSet[1].PDC), "Frame[17] OPCSet#1 PDC");
-    Assert.That(frameBytes[18..21], SequenceIs.EqualTo(opcSet[1].EDT), "Frame[18..21] OPCSet#1 EDT");
+    Assert.That(frameBytes[11], Is.EqualTo(propsSet.Count), "Frame[11] OPCSet");
+    Assert.That(frameBytes[12], Is.EqualTo(propsSet[0].EPC), "Frame[12] OPCSet#0 EPC");
+    Assert.That(frameBytes[13], Is.EqualTo(propsSet[0].PDC), "Frame[13] OPCSet#0 PDC");
+    Assert.That(frameBytes[14..16], SequenceIs.EqualTo(propsSet[0].EDT), "Frame[14..16] OPCSet#0 EDT");
+    Assert.That(frameBytes[16], Is.EqualTo(propsSet[1].EPC), "Frame[16] OPCSet#1 EPC");
+    Assert.That(frameBytes[17], Is.EqualTo(propsSet[1].PDC), "Frame[17] OPCSet#1 PDC");
+    Assert.That(frameBytes[18..21], SequenceIs.EqualTo(propsSet[1].EDT), "Frame[18..21] OPCSet#1 EDT");
 
-    Assert.That(frameBytes[21], Is.EqualTo(opcGet.Count), "Frame[21] OPCGet");
-    Assert.That(frameBytes[22], Is.EqualTo(opcGet[0].EPC), "Frame[22] OPCGet#0 EPC");
-    Assert.That(frameBytes[23], Is.EqualTo(opcGet[0].PDC), "Frame[23] OPCGet#0 PDC");
-    Assert.That(frameBytes[24..28], SequenceIs.EqualTo(opcGet[0].EDT), "Frame[24..28] OPCGet#0 EDT");
+    Assert.That(frameBytes[21], Is.EqualTo(propsGet.Count), "Frame[21] OPCGet");
+    Assert.That(frameBytes[22], Is.EqualTo(propsGet[0].EPC), "Frame[22] OPCGet#0 EPC");
+    Assert.That(frameBytes[23], Is.EqualTo(propsGet[0].PDC), "Frame[23] OPCGet#0 PDC");
+    Assert.That(frameBytes[24..28], SequenceIs.EqualTo(propsGet[0].EDT), "Frame[24..28] OPCGet#0 EDT");
   }
 
   [TestCase(ESV.SetGet)]
@@ -405,23 +405,23 @@ partial class FrameSerializerTests {
   [TestCase(ESV.SetGetServiceNotAvailable)]
   public void SerializeEchonetLiteFrameFormat1_OPCGet_ForMultipleProperty(ESV esv)
   {
-    var edtOPCSet = new byte[] { 0x11, 0x12 };
-    var opcSet = new List<PropertyRequest>() {
+    var edtSet = new byte[] { 0x11, 0x12 };
+    var propsSet = new List<PropertyRequest>() {
       new(
         epc: 0x10,
-        edt: edtOPCSet
+        edt: edtSet
       ),
     };
-    var edtOPCGet0 = new byte[] { 0x21, 0x22, 0x23 };
-    var edtOPCGet1 = new byte[] { 0x31, 0x32, 0x33, 0x34 };
-    var opcGet = new List<PropertyRequest>() {
+    var edtGet0 = new byte[] { 0x21, 0x22, 0x23 };
+    var edtGet1 = new byte[] { 0x31, 0x32, 0x33, 0x34 };
+    var propsGet = new List<PropertyRequest>() {
       new(
         epc: 0x20,
-        edt: edtOPCGet0
+        edt: edtGet0
       ),
       new(
         epc: 0x30,
-        edt: edtOPCGet1
+        edt: edtGet1
       ),
     };
 
@@ -433,8 +433,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      opcListOrOpcSetList: opcSet,
-      opcGetList: opcGet
+      propsForSetOrGet: propsSet,
+      propsForGet: propsGet
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -442,18 +442,18 @@ partial class FrameSerializerTests {
     Assert.That(frameBytes[0], Is.EqualTo(0x10), "Frame[0] EHD1");
     Assert.That(frameBytes[1], Is.EqualTo(0x81), "Frame[1] EHD2");
 
-    Assert.That(frameBytes[11], Is.EqualTo(opcSet.Count), "Frame[11] OPCSet");
-    Assert.That(frameBytes[12], Is.EqualTo(opcSet[0].EPC), "Frame[12] OPCSet#0 EPC");
-    Assert.That(frameBytes[13], Is.EqualTo(opcSet[0].PDC), "Frame[13] OPCSet#0 PDC");
-    Assert.That(frameBytes[14..16], SequenceIs.EqualTo(opcSet[0].EDT), "Frame[14..16] OPCSet#0 EDT");
+    Assert.That(frameBytes[11], Is.EqualTo(propsSet.Count), "Frame[11] OPCSet");
+    Assert.That(frameBytes[12], Is.EqualTo(propsSet[0].EPC), "Frame[12] OPCSet#0 EPC");
+    Assert.That(frameBytes[13], Is.EqualTo(propsSet[0].PDC), "Frame[13] OPCSet#0 PDC");
+    Assert.That(frameBytes[14..16], SequenceIs.EqualTo(propsSet[0].EDT), "Frame[14..16] OPCSet#0 EDT");
 
-    Assert.That(frameBytes[16], Is.EqualTo(opcGet.Count), "Frame[16] OPCGet");
-    Assert.That(frameBytes[17], Is.EqualTo(opcGet[0].EPC), "Frame[17] OPCGet#0 EPC");
-    Assert.That(frameBytes[18], Is.EqualTo(opcGet[0].PDC), "Frame[18] OPCGet#0 PDC");
-    Assert.That(frameBytes[19..22], SequenceIs.EqualTo(opcGet[0].EDT), "Frame[18..22] OPCGet#0 EDT");
-    Assert.That(frameBytes[22], Is.EqualTo(opcGet[1].EPC), "Frame[22] OPCGet#1 EPC");
-    Assert.That(frameBytes[23], Is.EqualTo(opcGet[1].PDC), "Frame[23] OPCGet#1 PDC");
-    Assert.That(frameBytes[24..28], SequenceIs.EqualTo(opcGet[1].EDT), "Frame[24..28] OPCGet#1 EDT");
+    Assert.That(frameBytes[16], Is.EqualTo(propsGet.Count), "Frame[16] OPCGet");
+    Assert.That(frameBytes[17], Is.EqualTo(propsGet[0].EPC), "Frame[17] OPCGet#0 EPC");
+    Assert.That(frameBytes[18], Is.EqualTo(propsGet[0].PDC), "Frame[18] OPCGet#0 PDC");
+    Assert.That(frameBytes[19..22], SequenceIs.EqualTo(propsGet[0].EDT), "Frame[18..22] OPCGet#0 EDT");
+    Assert.That(frameBytes[22], Is.EqualTo(propsGet[1].EPC), "Frame[22] OPCGet#1 EPC");
+    Assert.That(frameBytes[23], Is.EqualTo(propsGet[1].PDC), "Frame[23] OPCGet#1 PDC");
+    Assert.That(frameBytes[24..28], SequenceIs.EqualTo(propsGet[1].EDT), "Frame[24..28] OPCGet#1 EDT");
   }
 
   [Test]
@@ -472,12 +472,12 @@ partial class FrameSerializerTests {
 
   private static void SerializeEchonetLiteFrameFormat1_OPCSet_ForNoProperty(ESV esv)
   {
-    var edtOPCGet = new byte[] { 0x10, 0x11, 0x12, 0x13, 0x14 };
-    var opcSet = new List<PropertyRequest>(); // empty OPCSet
-    var opcGet = new List<PropertyRequest>() {
+    var edtGet = new byte[] { 0x10, 0x11, 0x12, 0x13, 0x14 };
+    var propsSet = new List<PropertyRequest>(); // empty props
+    var propsGet = new List<PropertyRequest>() {
       new(
         epc: 0xFF,
-        edt: edtOPCGet
+        edt: edtGet
       ),
     };
 
@@ -489,8 +489,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      opcListOrOpcSetList: opcSet,
-      opcGetList: opcGet
+      propsForSetOrGet: propsSet,
+      propsForGet: propsGet
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -500,10 +500,10 @@ partial class FrameSerializerTests {
 
     Assert.That(frameBytes[11], Is.EqualTo(0), "Frame[11] OPCSet");
 
-    Assert.That(frameBytes[12], Is.EqualTo(opcGet.Count), "Frame[12] OPCGet");
-    Assert.That(frameBytes[13], Is.EqualTo(opcGet[0].EPC), "Frame[13] OPCGet#0 EPC");
-    Assert.That(frameBytes[14], Is.EqualTo(opcGet[0].PDC), "Frame[14] OPCGet#0 PDC");
-    Assert.That(frameBytes[15..20], SequenceIs.EqualTo(opcGet[0].EDT), "Frame[15..20] OPCGet#0 EDT");
+    Assert.That(frameBytes[12], Is.EqualTo(propsGet.Count), "Frame[12] OPCGet");
+    Assert.That(frameBytes[13], Is.EqualTo(propsGet[0].EPC), "Frame[13] OPCGet#0 EPC");
+    Assert.That(frameBytes[14], Is.EqualTo(propsGet[0].PDC), "Frame[14] OPCGet#0 PDC");
+    Assert.That(frameBytes[15..20], SequenceIs.EqualTo(propsGet[0].EDT), "Frame[15..20] OPCGet#0 EDT");
   }
 
   [Test]
@@ -522,14 +522,14 @@ partial class FrameSerializerTests {
 
   private static void SerializeEchonetLiteFrameFormat1_OPCGet_ForNoProperty(ESV esv)
   {
-    var edtOPCSet = new byte[] { 0x10, 0x11, 0x12, 0x13, 0x14 };
-    var opcSet = new List<PropertyRequest>() {
+    var edtSet = new byte[] { 0x10, 0x11, 0x12, 0x13, 0x14 };
+    var propsSet = new List<PropertyRequest>() {
       new(
         epc: 0xFF,
-        edt: edtOPCSet
+        edt: edtSet
       ),
     };
-    var opcGet = new List<PropertyRequest>(); // empty OPCGet
+    var propsGet = new List<PropertyRequest>(); // empty props
 
     var buffer = new ArrayBufferWriter<byte>(initialCapacity: 0x100);
 
@@ -539,8 +539,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      opcListOrOpcSetList: opcSet,
-      opcGetList: opcGet
+      propsForSetOrGet: propsSet,
+      propsForGet: propsGet
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -548,10 +548,10 @@ partial class FrameSerializerTests {
     Assert.That(frameBytes[0], Is.EqualTo(0x10), "Frame[0] EHD1");
     Assert.That(frameBytes[1], Is.EqualTo(0x81), "Frame[1] EHD2");
 
-    Assert.That(frameBytes[11], Is.EqualTo(opcSet.Count), "Frame[11] OPCSet");
-    Assert.That(frameBytes[12], Is.EqualTo(opcSet[0].EPC), "Frame[12] OPCSet#0 EPC");
-    Assert.That(frameBytes[13], Is.EqualTo(opcSet[0].PDC), "Frame[13] OPCSet#0 PDC");
-    Assert.That(frameBytes[14..19], SequenceIs.EqualTo(opcSet[0].EDT), "Frame[14..19] OPCSet#0 EDT");
+    Assert.That(frameBytes[11], Is.EqualTo(propsSet.Count), "Frame[11] OPCSet");
+    Assert.That(frameBytes[12], Is.EqualTo(propsSet[0].EPC), "Frame[12] OPCSet#0 EPC");
+    Assert.That(frameBytes[13], Is.EqualTo(propsSet[0].PDC), "Frame[13] OPCSet#0 PDC");
+    Assert.That(frameBytes[14..19], SequenceIs.EqualTo(propsSet[0].EDT), "Frame[14..19] OPCSet#0 EDT");
 
     Assert.That(frameBytes[19], Is.EqualTo(0), "Frame[19] OPCGet");
   }

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Serialize.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/FrameSerializer.Serialize.cs
@@ -31,8 +31,7 @@ partial class FrameSerializerTests {
         sourceObject: default,
         destinationObject: default,
         esv: default,
-        propsForSetOrGet: Array.Empty<PropertyRequest>(),
-        propsForGet: Array.Empty<PropertyRequest>()
+        properties: Array.Empty<PropertyRequest>()
       ),
       message: "buffer null"
     );
@@ -47,11 +46,24 @@ partial class FrameSerializerTests {
         tid: ZeroTID,
         sourceObject: default,
         destinationObject: default,
-        esv: default,
-        propsForSetOrGet: null!,
-        propsForGet: null
+        esv: ESV.SetGet,
+        propertiesForSet: null!,
+        propertiesForGet: Array.Empty<PropertyRequest>()
       ),
-      message: "propsForSetOrGet null"
+      message: "propertiesForSet null"
+    );
+
+    Assert.Throws<ArgumentNullException>(
+      () => FrameSerializer.SerializeEchonetLiteFrameFormat1(
+        buffer: new ArrayBufferWriter<byte>(),
+        tid: ZeroTID,
+        sourceObject: default,
+        destinationObject: default,
+        esv: ESV.SetGet,
+        propertiesForSet: [ new() ],
+        propertiesForGet: null!
+      ),
+      message: "propertiesForGet null"
     );
   }
 
@@ -71,8 +83,7 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: default,
-      propsForSetOrGet: Array.Empty<PropertyRequest>(),
-      propsForGet: Array.Empty<PropertyRequest>()
+      properties: Array.Empty<PropertyRequest>()
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -116,8 +127,7 @@ partial class FrameSerializerTests {
       sourceObject: seoj,
       destinationObject: default,
       esv: default,
-      propsForSetOrGet: Array.Empty<PropertyRequest>(),
-      propsForGet: Array.Empty<PropertyRequest>()
+      properties: Array.Empty<PropertyRequest>()
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -146,8 +156,7 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: deoj,
       esv: default,
-      propsForSetOrGet: Array.Empty<PropertyRequest>(),
-      propsForGet: Array.Empty<PropertyRequest>()
+      properties: Array.Empty<PropertyRequest>()
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -182,21 +191,27 @@ partial class FrameSerializerTests {
   {
     var buffer = new ArrayBufferWriter<byte>(initialCapacity: 0x100);
 
-    FrameSerializer.SerializeEchonetLiteFrameFormat1(
-      buffer: buffer,
-      tid: ZeroTID,
-      sourceObject: default,
-      destinationObject: default,
-      esv: esv,
-      propsForSetOrGet: esv switch {
-        ESV.SetGet or ESV.SetGetResponse or ESV.SetGetServiceNotAvailable => [ new() ],
-        _ => Array.Empty<PropertyRequest>(),
-      },
-      propsForGet: esv switch {
-        ESV.SetGet or ESV.SetGetResponse or ESV.SetGetServiceNotAvailable => [ new() ],
-        _ => Array.Empty<PropertyRequest>(),
-      }
-    );
+    if (esv is ESV.SetGet or ESV.SetGetResponse or ESV.SetGetServiceNotAvailable) {
+      FrameSerializer.SerializeEchonetLiteFrameFormat1(
+        buffer: buffer,
+        tid: ZeroTID,
+        sourceObject: default,
+        destinationObject: default,
+        esv: esv,
+        propertiesForSet: [ new() ],
+        propertiesForGet: [ new() ]
+      );
+    }
+    else {
+      FrameSerializer.SerializeEchonetLiteFrameFormat1(
+        buffer: buffer,
+        tid: ZeroTID,
+        sourceObject: default,
+        destinationObject: default,
+        esv: esv,
+        properties: Array.Empty<PropertyRequest>()
+      );
+    }
 
     var frameBytes = buffer.WrittenMemory.ToArray();
 
@@ -237,8 +252,7 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      propsForSetOrGet: props,
-      propsForGet: Array.Empty<PropertyRequest>()
+      properties: props
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -277,8 +291,7 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      propsForSetOrGet: props,
-      propsForGet: Array.Empty<PropertyRequest>()
+      properties: props
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -324,8 +337,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      propsForSetOrGet: propsSet,
-      propsForGet: propsGet
+      propertiesForSet: propsSet,
+      propertiesForGet: propsGet
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -377,8 +390,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      propsForSetOrGet: propsSet,
-      propsForGet: propsGet
+      propertiesForSet: propsSet,
+      propertiesForGet: propsGet
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -433,8 +446,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      propsForSetOrGet: propsSet,
-      propsForGet: propsGet
+      propertiesForSet: propsSet,
+      propertiesForGet: propsGet
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -489,8 +502,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      propsForSetOrGet: propsSet,
-      propsForGet: propsGet
+      propertiesForSet: propsSet,
+      propertiesForGet: propsGet
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();
@@ -539,8 +552,8 @@ partial class FrameSerializerTests {
       sourceObject: default,
       destinationObject: default,
       esv: esv,
-      propsForSetOrGet: propsSet,
-      propsForGet: propsGet
+      propertiesForSet: propsSet,
+      propertiesForGet: propsGet
     );
 
     var frameBytes = buffer.WrittenMemory.ToArray();


### PR DESCRIPTION
### Description
ECHONET Lite電文処理関連の実装において、OPC・EPC・PDC・EDTの組み合わせの総称としてOPCListといった語彙を使用しているところを整理し、OPCとは区別して単にPropertyなどとする。
