### PR TITLE
プロファイルグループクラスオブジェクトのEOJ比較時にインスタンスコードを無視する

### DIFF
--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/EOJ.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/EOJ.cs
@@ -9,6 +9,9 @@ namespace Smdn.Net.EchonetLite.Protocol;
 /// ECHONET オブジェクト（EOJ）
 /// </summary>
 public readonly struct EOJ : IEquatable<EOJ> {
+  private const byte ClassGroupCodeForProfileClassGroup = 0x0E;
+  private const byte ClassCodeForNodeProfile = 0xF0;
+
   /// <summary>
   /// クラスグループコード
   /// </summary>
@@ -24,7 +27,7 @@ public readonly struct EOJ : IEquatable<EOJ> {
   /// </summary>
   public byte InstanceCode { get; }
 
-  internal bool IsNodeProfile => ClassGroupCode == 0x0E && ClassCode == 0xF0;
+  internal bool IsNodeProfile => ClassGroupCode == ClassGroupCodeForProfileClassGroup && ClassCode == ClassCodeForNodeProfile;
 
   /// <summary>
   /// ECHONET オブジェクト（EOJ）を記述する<see cref="EOJ"/>を作成します。
@@ -39,6 +42,29 @@ public readonly struct EOJ : IEquatable<EOJ> {
     InstanceCode = instanceCode;
   }
 
+  /// <summary>
+  /// 指定した2つのECHONET オブジェクトが同一であるかどうかを判断します。
+  /// </summary>
+  /// <remarks>
+  /// このメソッドでは、<see cref="ClassGroupCode"/>, <see cref="ClassCode"/>, <see cref="InstanceCode"/>の3つの値がすべて同一の場合に、2つのインスタンスは同一であると判断します。
+  /// ただし、プロファイルクラスグループのオブジェクト(<see cref="ClassGroupCode"/>の値が<c>0x0E</c>)の場合は、<see cref="ClassGroupCode"/>と<see cref="ClassCode"/>の2つの値がすべて同一の場合に、2つのインスタンスは同一であると判断し、<see cref="InstanceCode"/>の値は考慮されません。
+  /// </remarks>
+  /// <param name="x">比較する1つめのECHONET オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="y">比較する2つめのECHONET オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <returns>2つのECHONET オブジェクトが同じである場合、もしくはどちらも同じプロファイルクラスグループのオブジェクトである場合は<see langword="true"/>、そうでない場合は<see langword="false"/>。</returns>
+  public static bool AreSame(EOJ x, EOJ y)
+    => x.ClassGroupCode == ClassGroupCodeForProfileClassGroup && y.ClassGroupCode == ClassGroupCodeForProfileClassGroup
+      ? x.ClassCode == y.ClassCode // 同じプロファイルクラスグループのオブジェクトかどうか比較
+      : x == y; // 同じECHONETオブジェクトかどうか比較
+
+  /// <summary>
+  /// このECHONET オブジェクトと指定した<see cref="EOJ"/>が同一であるかどうかを判断します。
+  /// </summary>
+  /// <remarks>
+  /// このメソッドでは、<see cref="ClassGroupCode"/>, <see cref="ClassCode"/>, <see cref="InstanceCode"/>の3つの値がすべて同一の場合に、2つのインスタンスは同一であると判断します。
+  /// </remarks>
+  /// <param name="other">このインスタンスと比較するECHONET オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <returns>同一である場合は<see langword="true"/>、そうでない場合は<see langword="false"/>。</returns>
   public bool Equals(EOJ other)
     =>
       ClassGroupCode == other.ClassGroupCode &&
@@ -58,12 +84,30 @@ public readonly struct EOJ : IEquatable<EOJ> {
       ClassCode.GetHashCode() ^
       InstanceCode.GetHashCode();
 
+  /// <summary>
+  /// 指定された2つのECHONET オブジェクトが同じ値を持つかどうかを判断します。
+  /// </summary>
+  /// <remarks>
+  /// この演算子では、<see cref="ClassGroupCode"/>, <see cref="ClassCode"/>, <see cref="InstanceCode"/>の3つの値がすべて同一の場合に、2つのインスタンスは同じ値であると判断します。
+  /// </remarks>
+  /// <param name="c1">比較する1つめのECHONET オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="c2">比較する2つめのECHONET オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <returns>2つのインスタンスが同じ値である場合は<see langword="true"/>、そうでない場合は<see langword="false"/>。</returns>
   public static bool operator ==(EOJ c1, EOJ c2)
     =>
       c1.ClassGroupCode == c2.ClassGroupCode &&
       c1.ClassCode == c2.ClassCode &&
       c1.InstanceCode == c2.InstanceCode;
 
+  /// <summary>
+  /// 指定された2つのECHONET オブジェクトが異なる値を持つかどうかを判断します。
+  /// </summary>
+  /// <remarks>
+  /// この演算子では、<see cref="ClassGroupCode"/>, <see cref="ClassCode"/>, <see cref="InstanceCode"/>のいずれか1つの値でも異なる場合に、2つのインスタンスは異なる値であると判断します。
+  /// </remarks>
+  /// <param name="c1">比較する1つめのECHONET オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="c2">比較する2つめのECHONET オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <returns>2つのインスタンスが異なる値である場合は<see langword="true"/>、そうでない場合は<see langword="false"/>。</returns>
   public static bool operator !=(EOJ c1, EOJ c2)
     => !(c1 == c2);
 

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/EOJ.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/EOJ.cs
@@ -24,6 +24,8 @@ public readonly struct EOJ : IEquatable<EOJ> {
   /// </summary>
   public byte InstanceCode { get; }
 
+  internal bool IsNodeProfile => ClassGroupCode == 0x0E && ClassCode == 0xF0;
+
   /// <summary>
   /// ECHONET オブジェクト（EOJ）を記述する<see cref="EOJ"/>を作成します。
   /// </summary>

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Services.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Services.cs
@@ -1061,7 +1061,7 @@ partial class EchonetClient
       OnNodeJoined(sourceNode);
     }
 
-    var destObject = SelfNode.NodeProfile.EOJ == message.DEOJ
+    var destObject = message.DEOJ.IsNodeProfile
       ? SelfNode.NodeProfile // 自ノードプロファイル宛てのリクエストの場合
       : SelfNode.Devices.FirstOrDefault(d => d.EOJ == message.DEOJ);
 
@@ -1512,19 +1512,15 @@ partial class EchonetClient
   {
     var hasError = false;
     var requestProps = message.GetProperties();
-    var sourceObject = sourceNode.Devices.FirstOrDefault(d => d.EOJ == message.SEOJ);
+    var sourceObject = message.SEOJ.IsNodeProfile
+      ? sourceNode.NodeProfile // ノードプロファイルからの通知の場合
+      : sourceNode.Devices.FirstOrDefault(d => d.EOJ == message.SEOJ);
 
     if (sourceObject is null) {
-      // ノードプロファイルからの通知の場合
-      if (sourceNode.NodeProfile.EOJ == message.SEOJ) {
-        sourceObject = sourceNode.NodeProfile;
-      }
-      else {
-        // 未知のオブジェクト
-        // 新規作成(プロパティはない状態)
-        sourceObject = new(message.SEOJ);
-        sourceNode.Devices.Add(sourceObject);
-      }
+      // 未知のオブジェクト
+      // 新規作成(プロパティはない状態)
+      sourceObject = new(message.SEOJ);
+      sourceNode.Devices.Add(sourceObject);
     }
 
     foreach (var prop in requestProps) {
@@ -1594,19 +1590,15 @@ partial class EchonetClient
       hasError = true;
     }
 
-    var sourceObject = sourceNode.Devices.FirstOrDefault(d => d.EOJ == message.SEOJ);
+    var sourceObject = message.SEOJ.IsNodeProfile
+      ? sourceNode.NodeProfile // ノードプロファイルからの通知の場合
+      : sourceNode.Devices.FirstOrDefault(d => d.EOJ == message.SEOJ);
 
     if (sourceObject is null) {
-      // ノードプロファイルからの通知の場合
-      if (sourceNode.NodeProfile.EOJ == message.SEOJ) {
-        sourceObject = sourceNode.NodeProfile;
-      }
-      else {
-        // 未知のオブジェクト
-        // 新規作成(プロパティはない状態)
-        sourceObject = new(message.SEOJ);
-        sourceNode.Devices.Add(sourceObject);
-      }
+      // 未知のオブジェクト
+      // 新規作成(プロパティはない状態)
+      sourceObject = new(message.SEOJ);
+      sourceNode.Devices.Add(sourceObject);
     }
 
     foreach (var prop in requestProps) {

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Services.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Services.cs
@@ -261,7 +261,7 @@ partial class EchonetClient
 
         if (destinationNode is not null && !destinationNode.Address.Equals(value.Address))
           return;
-        if (value.Message.SEOJ != destinationObject.EOJ)
+        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject.EOJ))
           return;
         if (value.Message.ESV != ESV.SetIServiceNotAvailable)
           return;
@@ -377,7 +377,7 @@ partial class EchonetClient
 
         if (destinationNode is not null && !destinationNode.Address.Equals(value.Address))
           return;
-        if (value.Message.SEOJ != destinationObject.EOJ)
+        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject.EOJ))
           return;
         if (value.Message.ESV != ESV.SetCServiceNotAvailable && value.Message.ESV != ESV.SetResponse)
           return;
@@ -485,7 +485,7 @@ partial class EchonetClient
 
         if (destinationNode is not null && !destinationNode.Address.Equals(value.Address))
           return;
-        if (value.Message.SEOJ != destinationObject.EOJ)
+        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject.EOJ))
           return;
         if (value.Message.ESV != ESV.GetResponse && value.Message.ESV != ESV.GetServiceNotAvailable)
           return;
@@ -598,7 +598,7 @@ partial class EchonetClient
 
         if (destinationNode is not null && !destinationNode.Address.Equals(value.Address))
           return;
-        if (value.Message.SEOJ != destinationObject.EOJ)
+        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject.EOJ))
           return;
         if (value.Message.ESV != ESV.SetGetResponse && value.Message.ESV != ESV.SetGetServiceNotAvailable)
           return;
@@ -817,7 +817,7 @@ partial class EchonetClient
 
         if (!destinationNode.Address.Equals(value.Address))
           return;
-        if (value.Message.SEOJ != destinationObject.EOJ)
+        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject.EOJ))
           return;
         if (value.Message.ESV != ESV.InfCResponse)
           return;

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/EOJ.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/EOJ.cs
@@ -6,6 +6,66 @@ namespace Smdn.Net.EchonetLite.Protocol;
 
 [TestFixture]
 public class EOJTests {
+  private static System.Collections.IEnumerable YieldTestCases_EqualityComparison()
+  {
+    const bool same = true;
+    const bool notSame = false;
+    const bool equal = true;
+    const bool notEqual = false;
+
+    yield return new object[] { default(EOJ), default(EOJ), equal, same };
+
+    yield return new object[] { new EOJ(0x00, 0x00, 0x00), new EOJ(0x00, 0x00, 0x01), notEqual, notSame };
+    yield return new object[] { new EOJ(0x00, 0x00, 0x01), new EOJ(0x00, 0x00, 0x00), notEqual, notSame };
+    yield return new object[] { new EOJ(0x00, 0x00, 0x01), new EOJ(0x00, 0x00, 0x01), equal, same };
+
+    yield return new object[] { new EOJ(0x00, 0x00, 0x00), new EOJ(0x00, 0x01, 0x00), notEqual, notSame };
+    yield return new object[] { new EOJ(0x00, 0x01, 0x00), new EOJ(0x00, 0x00, 0x00), notEqual, notSame };
+    yield return new object[] { new EOJ(0x00, 0x01, 0x00), new EOJ(0x00, 0x01, 0x00), equal, same };
+    yield return new object[] { new EOJ(0x00, 0x01, 0x00), new EOJ(0x00, 0x01, 0x01), notEqual, notSame };
+
+    yield return new object[] { new EOJ(0x00, 0x00, 0x00), new EOJ(0x01, 0x00, 0x00), notEqual, notSame };
+    yield return new object[] { new EOJ(0x01, 0x00, 0x00), new EOJ(0x00, 0x00, 0x00), notEqual, notSame };
+    yield return new object[] { new EOJ(0x01, 0x00, 0x00), new EOJ(0x01, 0x00, 0x00), equal, same };
+    yield return new object[] { new EOJ(0x01, 0x00, 0x00), new EOJ(0x01, 0x00, 0x01), notEqual, notSame };
+
+    yield return new object[] { new EOJ(0x0E, 0xF0, 0x00), new EOJ(0x0E, 0xF0, 0x00), equal, same };
+    yield return new object[] { new EOJ(0x0E, 0xF0, 0x01), new EOJ(0x0E, 0xF0, 0x00), notEqual, same };
+    yield return new object[] { new EOJ(0x0E, 0xF0, 0x00), new EOJ(0x0E, 0xF0, 0x01), notEqual, same };
+    yield return new object[] { new EOJ(0x0E, 0xF0, 0x01), new EOJ(0x0E, 0xF0, 0x01), equal, same };
+
+    yield return new object[] { new EOJ(0x0E, 0x00, 0x00), new EOJ(0x0E, 0x00, 0x00), equal, same };
+    yield return new object[] { new EOJ(0x0E, 0x00, 0x00), new EOJ(0x0E, 0x00, 0x01), notEqual, same };
+
+    yield return new object[] { new EOJ(0x0E, 0x00, 0x00), new EOJ(0x0E, 0x01, 0x00), notEqual, notSame };
+    yield return new object[] { new EOJ(0x0E, 0x00, 0x00), new EOJ(0x0E, 0x01, 0x01), notEqual, notSame };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_EqualityComparison))]
+  public void AreSame(EOJ x, EOJ y, bool _, bool expectedAsSame)
+    => Assert.That(EOJ.AreSame(x, y), Is.EqualTo(expectedAsSame));
+
+  [TestCaseSource(nameof(YieldTestCases_EqualityComparison))]
+  public void Equals(EOJ x, EOJ y, bool expectedAsEqual, bool _)
+  {
+    Assert.That(x.Equals(y), Is.EqualTo(expectedAsEqual));
+    Assert.That(y.Equals(x), Is.EqualTo(expectedAsEqual));
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_EqualityComparison))]
+  public void op_Equality(EOJ x, EOJ y, bool expectedAsEqual, bool _)
+  {
+    Assert.That(x == y, Is.EqualTo(expectedAsEqual));
+    Assert.That(y == x, Is.EqualTo(expectedAsEqual));
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_EqualityComparison))]
+  public void op_Inequality(EOJ x, EOJ y, bool expectedAsEqual, bool _)
+  {
+    Assert.That(x != y, Is.EqualTo(!expectedAsEqual));
+    Assert.That(y != x, Is.EqualTo(!expectedAsEqual));
+  }
+
   [TestCase(0x00, 0x00, 0x00, "00.00 00")]
   [TestCase(0x01, 0x00, 0x00, "01.00 00")]
   [TestCase(0x0F, 0x00, 0x00, "0F.00 00")]

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/PropertyValue.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/PropertyValue.cs
@@ -1,10 +1,40 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
+using System;
+
 using NUnit.Framework;
 
 namespace Smdn.Net.EchonetLite.Protocol;
 
 [TestFixture]
 public class PropertyValueTests {
+  [Test]
+  public void Default()
+  {
+    var p = default(PropertyValue);
+
+    Assert.That(p.EPC, Is.EqualTo(0x00));
+    Assert.That(p.PDC, Is.EqualTo(0));
+    Assert.That(p.EDT.IsEmpty, Is.True);
+  }
+
+  [Test]
+  public void Ctor_Empty()
+  {
+    var p = new PropertyValue(0x00, ReadOnlyMemory<byte>.Empty);
+
+    Assert.That(p.EPC, Is.EqualTo(0x00));
+    Assert.That(p.PDC, Is.EqualTo(0));
+    Assert.That(p.EDT.IsEmpty, Is.True);
+  }
+
+  [Test]
+  public void Ctor_ArgumentException()
+  {
+    Assert.That(
+      () => new PropertyValue(0x00, new byte[0x100]),
+      Throws.ArgumentException
+    );
+  }
 }
 


### PR DESCRIPTION
### Description
ノードプロファイルなど、各プロファイルグループクラスのオブジェクトはノードごとに1つ存在する。
したがって、EOJがプロファイルグループクラスのオブジェクトを表す場合は、インスタンスコードを比較しないようにする必要がある。

そこで、`EOJ.IsNodeProfile`プロパティを追加して、EOJがノードプロファイルを表すかどうかを判断するプロパティを追加する。
また、`EOJ.AreSame`メソッドを追加して、EOJが同一のECHONET オブジェクト、もしくは同一のプロファイルクラスグループのオブジェクトかどうかを判断するメソッドを追加する。

これらを用いて、EOJの比較時にプロファイルグループクラスのオブジェクトが正しく扱われるようにする。