### PR TITLE
ISynchronizeInvokeを使用したイベント発火を実装する

### DIFF
--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ComponentModel/IEventInvoker.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ComponentModel/IEventInvoker.cs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.ComponentModel;
+
+namespace Smdn.Net.EchonetLite.ComponentModel;
+
+/// <summary>
+/// <see cref="EventHandler{TEventArgs}"/>のイベント型に共通してイベントハンドラーの呼び出しを行う機能を提供します。
+/// このインターフェイスの実装では、必要に応じて<see cref="ISynchronizeInvoke"/>によってイベントハンドラー呼び出しをマーシャリングします。
+/// </summary>
+public interface IEventInvoker {
+  /// <summary>
+  /// イベントの結果として発行されるイベントハンドラー呼び出しをマーシャリングするために使用する<see cref="ISynchronizeInvoke"/>オブジェクトを取得または設定します。
+  /// </summary>
+  ISynchronizeInvoke? SynchronizingObject { get; set; }
+
+  /// <summary>
+  /// イベントハンドラーの呼び出しを行い、イベント型<see cref="EventHandler{TEventArgs}"/>のイベントを発生させます。
+  /// </summary>
+  /// <remarks>
+  /// イベントハンドラー呼び出しをマーシャリングするために、必要に応じて<see cref="ISynchronizeInvoke"/>が使用されます。
+  /// </remarks>
+  /// <typeparam name="TEventArgs">イベントハンドラーで使用されるイベント引数の型。</typeparam>
+  /// <param name="sender">イベントのソース。</param>
+  /// <param name="eventHandler">発生させるイベントのイベントハンドラー。</param>
+  /// <param name="e">発生させるイベントのイベント引数。</param>
+  void InvokeEvent<TEventArgs>(
+    object? sender,
+    EventHandler<TEventArgs>? eventHandler,
+    TEventArgs e
+  ); // `RaiseEvent` cannot be used to name this method.
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/DetailedEchonetProperty.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/DetailedEchonetProperty.cs
@@ -8,6 +8,8 @@ namespace Smdn.Net.EchonetLite;
 /// 詳細仕様が参照可能なECHONET プロパティを表すクラスです。
 /// </summary>
 internal sealed class DetailedEchonetProperty : EchonetProperty {
+  public override EchonetObject Device { get; }
+
   public override byte Code => Detail.Code;
   public override bool CanSet => Detail.CanSet;
   public override bool CanGet => Detail.CanGet;
@@ -22,8 +24,8 @@ internal sealed class DetailedEchonetProperty : EchonetProperty {
     EchonetObject device,
     IEchonetPropertySpecification propertyDetail
   )
-    : base(device)
   {
+    Device = device ?? throw new ArgumentNullException(nameof(device));
     Detail = propertyDetail ?? throw new ArgumentNullException(nameof(propertyDetail));
   }
 

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Events.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Events.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
+using Smdn.Net.EchonetLite.ComponentModel;
+
 namespace Smdn.Net.EchonetLite;
 
 #pragma warning disable IDE0040
@@ -142,6 +144,20 @@ partial class EchonetClient
     EventHandler<TEventArgs>? eventHandler,
     TEventArgs e
   )
+    => InvokeEvent(this, eventHandler, e);
+
+  void IEventInvoker.InvokeEvent<TEventArgs>(
+    object? sender,
+    EventHandler<TEventArgs>? eventHandler,
+    TEventArgs e
+  )
+    => InvokeEvent(sender, eventHandler, e);
+
+  protected void InvokeEvent<TEventArgs>(
+    object? sender,
+    EventHandler<TEventArgs>? eventHandler,
+    TEventArgs e
+  )
   {
     if (eventHandler is null)
       return;
@@ -150,7 +166,7 @@ partial class EchonetClient
 
     if (synchronizingObject is null || !synchronizingObject.InvokeRequired) {
       try {
-        eventHandler(this, e);
+        eventHandler(sender, e);
       }
 #pragma warning disable CA1031
       catch {
@@ -161,7 +177,7 @@ partial class EchonetClient
     else {
       _ = synchronizingObject.BeginInvoke(
         method: eventHandler,
-        args: [this, e]
+        args: [sender, e]
       );
     }
   }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
@@ -10,11 +10,12 @@ using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 
+using Smdn.Net.EchonetLite.ComponentModel;
 using Smdn.Net.EchonetLite.Transport;
 
 namespace Smdn.Net.EchonetLite;
 
-public partial class EchonetClient : IDisposable, IAsyncDisposable {
+public partial class EchonetClient : IEventInvoker, IDisposable, IAsyncDisposable {
   private readonly bool shouldDisposeEchonetLiteHandler;
   private IEchonetLiteHandler echonetLiteHandler; // null if disposed
   private readonly ILogger? logger;

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetNode.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetNode.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Net;
 
+using Smdn.Net.EchonetLite.ComponentModel;
 using Smdn.Net.EchonetLite.Protocol;
 
 namespace Smdn.Net.EchonetLite;
@@ -24,6 +25,13 @@ public abstract class EchonetNode {
   /// 現在このインスタンスを管理している<see cref="EchonetClient"/>を取得します。
   /// </summary>
   internal EchonetClient? Owner { get; set; }
+
+  /// <summary>
+  /// このインスタンスでイベントを発生させるために使用される<see cref="IEventInvoker"/>を取得します。
+  /// </summary>
+  /// <exception cref="InvalidOperationException"><see cref="IEventInvoker"/>を取得することができません。</exception>
+  internal IEventInvoker EventInvoker
+    => Owner ?? throw new InvalidOperationException($"{nameof(EventInvoker)} can not be null.");
 
   /// <summary>
   /// 下位スタックのアドレスを表す<see cref="IPAddress"/>を取得します。
@@ -48,7 +56,7 @@ public abstract class EchonetNode {
   /// このインスタンスが他のECHONET Liteノード(他ノード)を表す場合、ノードへECHONET Lite オブジェクトが追加された際にイベントが発生します。
   /// 変更の詳細は、イベント引数<see cref="NotifyCollectionChangedEventArgs"/>を参照してください。
   /// </remarks>
-  public event NotifyCollectionChangedEventHandler? DevicesChanged;
+  public event EventHandler<NotifyCollectionChangedEventArgs>? DevicesChanged;
 
   private protected EchonetNode(EchonetObject nodeProfile)
   {
@@ -58,7 +66,5 @@ public abstract class EchonetNode {
   protected internal abstract EchonetObject? FindDevice(EOJ eoj);
 
   private protected void OnDevicesChanged(NotifyCollectionChangedEventArgs e)
-  {
-    DevicesChanged?.Invoke(this, e);
-  }
+    => EventInvoker.InvokeEvent(this, DevicesChanged, e);
 }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
@@ -31,6 +31,22 @@ public abstract partial class EchonetObject {
   public event NotifyCollectionChangedEventHandler? PropertiesChanged;
 
   /// <summary>
+  /// このオブジェクトが属するECHONET Liteノードを表す<see cref="EchonetNode"/>を取得します。
+  /// </summary>
+  public EchonetNode Node {
+    get {
+#if DEBUG
+      if (OwnerNode is null)
+        throw new InvalidOperationException($"{nameof(OwnerNode)} is null");
+#endif
+
+      return OwnerNode!;
+    }
+  }
+
+  internal EchonetNode? OwnerNode { get; set; }
+
+  /// <summary>
   /// プロパティマップが取得済みであるかどうかを表す<see langword="bool"/>型の値を取得します。
   /// </summary>
   /// <value>
@@ -83,6 +99,29 @@ public abstract partial class EchonetObject {
   /// ANNOプロパティの一覧
   /// </summary>
   public virtual IEnumerable<EchonetProperty> AnnoProperties => Properties.Where(static p => p.CanAnnounceStatusChange);
+
+  /// <summary>
+  /// このオブジェクトが属するECHONET Liteノードを指定せずにインスタンスを作成します。
+  /// </summary>
+  /// <remarks>
+  /// このコンストラクタを使用してインスタンスを作成した場合、インスタンスが使用されるまでの間に、
+  /// <see cref="OwnerNode"/>プロパティへ明示的に<see cref="EchonetNode"/>を設定する必要があります。
+  /// </remarks>
+  private protected EchonetObject()
+  {
+  }
+
+  /// <summary>
+  /// このオブジェクトが属するECHONET Liteノードを指定してインスタンスを作成します。
+  /// </summary>
+  /// <param name="node">このオブジェクトが属するECHONET Liteノードを表す<see cref="EchonetNode"/>を指定します。</param>
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="node"/>が<see langword="null"/>です。
+  /// </exception>
+  private protected EchonetObject(EchonetNode node)
+  {
+    OwnerNode = node ?? throw new ArgumentNullException(nameof(node));
+  }
 
   private protected void OnPropertiesChanged(NotifyCollectionChangedEventArgs e)
   {

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 
+using Smdn.Net.EchonetLite.ComponentModel;
 using Smdn.Net.EchonetLite.Protocol;
 
 namespace Smdn.Net.EchonetLite;
@@ -28,7 +29,7 @@ public abstract partial class EchonetObject {
   /// 現在のオブジェクトにECHONET Lite プロパティが追加・削除された際にイベントが発生します。
   /// 変更の詳細は、イベント引数<see cref="NotifyCollectionChangedEventArgs"/>を参照してください。
   /// </remarks>
-  public event NotifyCollectionChangedEventHandler? PropertiesChanged;
+  public event EventHandler<NotifyCollectionChangedEventArgs>? PropertiesChanged;
 
   /// <summary>
   /// このオブジェクトが属するECHONET Liteノードを表す<see cref="EchonetNode"/>を取得します。
@@ -45,6 +46,13 @@ public abstract partial class EchonetObject {
   }
 
   internal EchonetNode? OwnerNode { get; set; }
+
+  /// <summary>
+  /// このインスタンスでイベントを発生させるために使用される<see cref="IEventInvoker"/>を取得します。
+  /// </summary>
+  /// <exception cref="InvalidOperationException"><see cref="IEventInvoker"/>を取得することができません。</exception>
+  protected virtual IEventInvoker EventInvoker
+    => OwnerNode?.EventInvoker ?? throw new InvalidOperationException($"{nameof(EventInvoker)} can not be null.");
 
   /// <summary>
   /// プロパティマップが取得済みであるかどうかを表す<see langword="bool"/>型の値を取得します。
@@ -124,8 +132,5 @@ public abstract partial class EchonetObject {
   }
 
   private protected void OnPropertiesChanged(NotifyCollectionChangedEventArgs e)
-  {
-    // TODO: use ISynchronizeInvoke
-    PropertiesChanged?.Invoke(this, e);
-  }
+    => EventInvoker.InvokeEvent(this, PropertiesChanged, e);
 }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetOtherNode.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetOtherNode.cs
@@ -42,7 +42,7 @@ internal sealed class EchonetOtherNode : EchonetNode {
     if (devices.TryGetValue(eoj, out var device))
       return device;
 
-    var newDevice = new UnspecifiedEchonetObject(eoj);
+    var newDevice = new UnspecifiedEchonetObject(this, eoj);
 
     device = devices.GetOrAdd(eoj, newDevice);
 

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Buffers;
 
+using Smdn.Net.EchonetLite.ComponentModel;
+
 namespace Smdn.Net.EchonetLite;
 
 /// <summary>
@@ -24,25 +26,6 @@ namespace Smdn.Net.EchonetLite;
 /// </seealso>
 public abstract class EchonetProperty {
   /// <summary>
-  /// 詳細仕様を指定して<see cref="EchonetProperty"/>インスタンスを作成します。
-  /// </summary>
-  /// <param name="device">このプロパティが属するECHONET オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="propertyDetail">プロパティの詳細仕様を表す<see cref="IEchonetPropertySpecification"/>。</param>
-  /// <returns>作成された<see cref="EchonetProperty"/>インスタンス。</returns>
-  /// <exception cref="ArgumentNullException">
-  /// <paramref name="device"/>が<see langword="null"/>です。
-  /// または、<paramref name="propertyDetail"/>が<see langword="null"/>です。
-  /// </exception>
-  public static EchonetProperty Create(
-    EchonetObject device,
-    IEchonetPropertySpecification propertyDetail
-  )
-    => new DetailedEchonetProperty(
-      device: device ?? throw new ArgumentNullException(nameof(device)),
-      propertyDetail: propertyDetail ?? throw new ArgumentNullException(nameof(propertyDetail))
-    );
-
-  /// <summary>
   /// このインスタンスのプロパティ値データ(EDT)に変更があった場合に発生するイベント。
   /// </summary>
   /// <remarks>
@@ -57,6 +40,13 @@ public abstract class EchonetProperty {
   /// このインスタンスが属するECHONETオブジェクトを表す<see cref="EchonetObject"/>を取得します。
   /// </summary>
   public abstract EchonetObject Device { get; }
+
+  /// <summary>
+  /// このインスタンスでイベントを発生させるために使用される<see cref="IEventInvoker"/>を取得します。
+  /// </summary>
+  /// <exception cref="InvalidOperationException"><see cref="IEventInvoker"/>を取得することができません。</exception>
+  protected virtual IEventInvoker EventInvoker
+    => Device.OwnerNode?.EventInvoker ?? throw new InvalidOperationException($"{nameof(EventInvoker)} can not be null.");
 
   /// <summary>
   /// プロパティ値を保持するバッファとなる<see cref="IBufferWriter{T}"/> 。
@@ -138,7 +128,10 @@ public abstract class EchonetProperty {
   /// <summary>
   /// コンストラクタ。
   /// </summary>
-  private protected EchonetProperty()
+  /// <remarks>
+  /// このコンストラクタはテスト目的で公開されています。　コードから直接使用することを意図したものではありません。
+  /// </remarks>
+  protected /* private protected */ EchonetProperty()
   {
   }
 
@@ -246,8 +239,7 @@ public abstract class EchonetProperty {
         var oldValueMemory = oldValue is null ? ReadOnlyMemory<byte>.Empty : oldValue.AsMemory(0, oldValueLength);
         var newValueMemory = value.WrittenMemory;
 
-        // TODO: use ISynchronizeInvoke; Device.SynchronizingObject.Invoke(...)
-        valueChangedHandlers.Invoke(this, (oldValueMemory, newValueMemory));
+        EventInvoker.InvokeEvent(this, valueChangedHandlers, e: (oldValueMemory, newValueMemory));
       }
     }
     finally {

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
@@ -54,9 +54,9 @@ public abstract class EchonetProperty {
   public event EventHandler<(ReadOnlyMemory<byte> OldValue, ReadOnlyMemory<byte> NewValue)>? ValueChanged;
 
   /// <summary>
-  /// このインスタンスが属するECHONETオブジェクトを表す<see cref="EchonetObject"/>を返します。
+  /// このインスタンスが属するECHONETオブジェクトを表す<see cref="EchonetObject"/>を取得します。
   /// </summary>
-  public EchonetObject Device { get; }
+  public abstract EchonetObject Device { get; }
 
   /// <summary>
   /// プロパティ値を保持するバッファとなる<see cref="IBufferWriter{T}"/> 。
@@ -138,13 +138,8 @@ public abstract class EchonetProperty {
   /// <summary>
   /// コンストラクタ。
   /// </summary>
-  /// <param name="device">このプロパティが属するECHONET オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <exception cref="ArgumentNullException">
-  /// <paramref name="device"/>が<see langword="null"/>です。
-  /// </exception>
-  private protected EchonetProperty(EchonetObject device)
+  private protected EchonetProperty()
   {
-    Device = device ?? throw new ArgumentNullException(nameof(device));
   }
 
   /// <summary>

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetSelfNode.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetSelfNode.cs
@@ -30,6 +30,10 @@ internal sealed class EchonetSelfNode : EchonetNode {
     : base(nodeProfile)
   {
     this.devices = new(devices);
+
+    foreach (var device in this.devices) {
+      device.OwnerNode = this;
+    }
   }
 
   protected internal override EchonetObject? FindDevice(EOJ eoj)

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetObject.cs
@@ -25,7 +25,8 @@ internal sealed class UnspecifiedEchonetObject : EchonetObject {
   public override IEnumerable<EchonetProperty> SetProperties => Properties.Where(static p => p.CanSet);
   public override IEnumerable<EchonetProperty> AnnoProperties => Properties.Where(static p => p.CanAnnounceStatusChange);
 
-  internal UnspecifiedEchonetObject(EOJ eoj)
+  internal UnspecifiedEchonetObject(EchonetNode node, EOJ eoj)
+    : base(node)
   {
     ClassGroupCode = eoj.ClassGroupCode;
     ClassCode = eoj.ClassCode;

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetProperty.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetProperty.cs
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
+using System;
+
 namespace Smdn.Net.EchonetLite;
 
 /// <summary>
@@ -7,6 +9,7 @@ namespace Smdn.Net.EchonetLite;
 /// 他のECHONET Liteノード(他ノード)に属するオブジェクトから通知されたプロパティなど、詳細仕様が未参照・未解決・不明なプロパティを表します。
 /// </summary>
 internal sealed class UnspecifiedEchonetProperty : EchonetProperty {
+  public override EchonetObject Device { get; }
   public override byte Code { get; }
   public override bool CanSet { get; }
   public override bool CanGet { get; }
@@ -19,8 +22,8 @@ internal sealed class UnspecifiedEchonetProperty : EchonetProperty {
     bool canGet,
     bool canAnnounceStatusChange
   )
-    : base(device)
   {
+    Device = device ?? throw new ArgumentNullException(nameof(device));
     Code = code;
     CanSet = canSet;
     CanGet = canGet;


### PR DESCRIPTION
### Description
- `IEventInvoker`を導入して`ISynchronizeInvoke`を使用したイベント呼び出しAPIを追加する
- `EchonetNode/Object/Property`にオブジェクト同士の関係を定義するプロパティを追加して、参照すべきIEventInvokerへのアクセスを可能にする
- イベント型を個別のイベント型から、`EventHandler<TEventArgs>`に統一する
