### PR TITLE
各ESVにおけるEDTの処理を整理・修正する

### DIFF
--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/DetailedEchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/DetailedEchonetObject.cs
@@ -54,9 +54,9 @@ internal sealed class DetailedEchonetObject : EchonetObject {
     readOnlyPropertiesView = new(properties);
   }
 
-  protected internal override bool StorePropertyValue(
+  internal override bool StorePropertyValue(
     ESV esv,
-    int tid,
+    ushort tid,
     PropertyValue value,
     bool validateValue
   )
@@ -69,7 +69,7 @@ internal sealed class DetailedEchonetObject : EchonetObject {
       // 詳細仕様の規定に違反する値のため、格納しない
       return false;
 
-    property.SetValue(esv, unchecked((ushort)tid), value);
+    property.SetValue(esv, tid, value);
 
     return true;
   }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/DetailedEchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/DetailedEchonetObject.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using Smdn.Net.EchonetLite.Protocol;
+
 namespace Smdn.Net.EchonetLite;
 
 /// <summary>
@@ -60,5 +62,27 @@ internal sealed class DetailedEchonetObject : EchonetObject {
     properties = new(
       objectDetail.Properties.Select(propertyDetail => new DetailedEchonetProperty(this, propertyDetail))
     );
+  }
+
+  protected internal override bool StorePropertyValue(
+    ESV esv,
+    int tid,
+    PropertyValue value,
+    bool validateValue
+  )
+  {
+    var property = properties.FirstOrDefault(p => p.Code == value.EPC);
+
+    if (property is null)
+      // 詳細仕様で規定されていないプロパティのため、格納しない
+      return false;
+
+    if (validateValue && !property.IsAcceptableValue(value.EDT.Span))
+      // 詳細仕様の規定に違反する値のため、格納しない
+      return false;
+
+    property.SetValue(esv, unchecked((ushort)tid), value);
+
+    return true;
   }
 }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/DetailedEchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/DetailedEchonetObject.cs
@@ -33,21 +33,6 @@ internal sealed class DetailedEchonetObject : EchonetObject {
   private readonly ReadOnlyEchonetPropertyDictionary<DetailedEchonetProperty> readOnlyPropertiesView;
 
   /// <summary>
-  /// GETプロパティの一覧
-  /// </summary>
-  public override IEnumerable<EchonetProperty> GetProperties => properties.Values.Where(static p => p.Detail.CanGet);
-
-  /// <summary>
-  /// SETプロパティの一覧
-  /// </summary>
-  public override IEnumerable<EchonetProperty> SetProperties => properties.Values.Where(static p => p.Detail.CanSet);
-
-  /// <summary>
-  /// ANNOプロパティの一覧
-  /// </summary>
-  public override IEnumerable<EchonetProperty> AnnoProperties => properties.Values.Where(static p => p.Detail.CanAnnounceStatusChange);
-
-  /// <summary>
   /// スペック指定のコンストラクタ
   /// プロパティは仕様から取得する
   /// </summary>

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -422,25 +423,19 @@ partial class EchonetClient
     }
     else {
       foreach (var prop in requestProps) {
-        // FIXME: 読み出し要求なので格納は不要
-        var accepted = destObject.StorePropertyValue(
-          esv: ESV.Get,
-          tid: tid,
-          value: prop,
-          validateValue: false
-        );
+        var property = destObject.Properties.FirstOrDefault(p => p.Code == prop.EPC);
 
-        if (!accepted) {
+        if (property is null) {
           hasError = true;
           // 要求を受理しなかった EPC に対しては、それに続く PDC に 0 を設定して
           // EDT はつけず、要求を受理できなかったことを示す。
           // (そのままでよい)
-          responseProps.Add(prop); // FIXME: 実装とコメントの不一致、逆になっている
+          responseProps.Add(new(prop.EPC));
         }
         else {
           // 要求を受理した EPCに対しては、それに続く PDC に読み出したプロパティの長さを、
           // EDT には読み出したプロパティ値を設定する
-          responseProps.Add(new(prop.EPC)); // FIXME: 実装とコメントの不一致、逆になっている
+          responseProps.Add(new(prop.EPC, property.ValueMemory));
         }
       }
     }
@@ -527,25 +522,19 @@ partial class EchonetClient
       }
 
       foreach (var prop in requestPropsForGet) {
-        // FIXME: 読み出し要求なので格納は不要
-        var accepted = destObject.StorePropertyValue(
-          esv: ESV.SetGet,
-          tid: tid,
-          value: prop,
-          validateValue: false
-        );
+        var property = destObject.Properties.FirstOrDefault(p => p.Code == prop.EPC);
 
-        if (accepted) {
+        if (property is null) {
           hasError = true;
           // 要求を受理しなかった EPC に対しては、それに続く PDC に 0 を設定して
           // EDT はつけず、要求を受理できなかったことを示す。
           // (そのままでよい)
-          responsePropsForGet.Add(prop); // FIXME: 実装とコメントの不一致、逆になっている
+          responsePropsForGet.Add(new(prop.EPC));
         }
         else {
           // 要求を受理した EPCに対しては、それに続く PDC に読み出したプロパティの長さを、
           // EDT には読み出したプロパティ値を設定する
-          responsePropsForGet.Add(new(prop.EPC)); // FIXME: 実装とコメントの不一致、逆になっている
+          responsePropsForGet.Add(new(prop.EPC, property.ValueMemory));
         }
       }
     }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -423,9 +422,7 @@ partial class EchonetClient
     }
     else {
       foreach (var prop in requestProps) {
-        var property = destObject.Properties.FirstOrDefault(p => p.Code == prop.EPC);
-
-        if (property is null) {
+        if (!destObject.Properties.TryGetValue(prop.EPC, out var property)) {
           hasError = true;
           // 要求を受理しなかった EPC に対しては、それに続く PDC に 0 を設定して
           // EDT はつけず、要求を受理できなかったことを示す。
@@ -522,9 +519,7 @@ partial class EchonetClient
       }
 
       foreach (var prop in requestPropsForGet) {
-        var property = destObject.Properties.FirstOrDefault(p => p.Code == prop.EPC);
-
-        if (property is null) {
+        if (!destObject.Properties.TryGetValue(prop.EPC, out var property)) {
           hasError = true;
           // 要求を受理しなかった EPC に対しては、それに続く PDC に 0 を設定して
           // EDT はつけず、要求を受理できなかったことを示す。

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
@@ -274,15 +274,15 @@ partial class EchonetClient
         validateValue: true // Setされる内容を検証する
       );
 
-      if (!accepted) {
+      if (accepted) {
+        // 要求を受理した EPC に対しては、それに続くPDCに0を設定してEDTは付けない
+        responseProps.Add(new(prop.EPC));
+      }
+      else {
         hasError = true;
         // 要求を受理しなかったEPCに対しては、それに続く PDC に要求時と同じ値を設定し、
         // 要求された EDT を付け、要求を受理できなかったことを示す。
         responseProps.Add(prop);
-      }
-      else {
-        // 要求を受理した EPC に対しては、それに続くPDCに0を設定してEDTは付けない
-        responseProps.Add(new(prop.EPC));
       }
     }
 
@@ -352,15 +352,15 @@ partial class EchonetClient
           validateValue: true // Setされる内容を検証する
         );
 
-        if (!accepted) {
+        if (accepted) {
+          // 要求を受理した EPC に対しては、それに続くPDCに0を設定してEDTは付けない
+          responseProps.Add(new(prop.EPC));
+        }
+        else {
           hasError = true;
           // 要求を受理しなかったEPCに対しては、それに続く PDC に要求時と同じ値を設定し、
           // 要求された EDT を付け、要求を受理できなかったことを示す。
           responseProps.Add(prop);
-        }
-        else {
-          // 要求を受理した EPC に対しては、それに続くPDCに0を設定してEDTは付けない
-          responseProps.Add(new(prop.EPC));
         }
       }
     }
@@ -422,17 +422,17 @@ partial class EchonetClient
     }
     else {
       foreach (var prop in requestProps) {
-        if (!destObject.Properties.TryGetValue(prop.EPC, out var property)) {
+        if (destObject.Properties.TryGetValue(prop.EPC, out var property)) {
+          // 要求を受理した EPCに対しては、それに続く PDC に読み出したプロパティの長さを、
+          // EDT には読み出したプロパティ値を設定する
+          responseProps.Add(new(prop.EPC, property.ValueMemory));
+        }
+        else {
           hasError = true;
           // 要求を受理しなかった EPC に対しては、それに続く PDC に 0 を設定して
           // EDT はつけず、要求を受理できなかったことを示す。
           // (そのままでよい)
           responseProps.Add(new(prop.EPC));
-        }
-        else {
-          // 要求を受理した EPCに対しては、それに続く PDC に読み出したプロパティの長さを、
-          // EDT には読み出したプロパティ値を設定する
-          responseProps.Add(new(prop.EPC, property.ValueMemory));
         }
       }
     }
@@ -506,30 +506,30 @@ partial class EchonetClient
           validateValue: true // Setされる内容を検証する
         );
 
-        if (!accepted) {
+        if (accepted) {
+          // 要求を受理した EPC に対しては、それに続くPDCに0を設定してEDTは付けない
+          responsePropsForSet.Add(new(prop.EPC));
+        }
+        else {
           hasError = true;
           // 要求を受理しなかったEPCに対しては、それに続く PDC に要求時と同じ値を設定し、
           // 要求された EDT を付け、要求を受理できなかったことを示す。
           responsePropsForSet.Add(prop);
         }
-        else {
-          // 要求を受理した EPC に対しては、それに続くPDCに0を設定してEDTは付けない
-          responsePropsForSet.Add(new(prop.EPC));
-        }
       }
 
       foreach (var prop in requestPropsForGet) {
-        if (!destObject.Properties.TryGetValue(prop.EPC, out var property)) {
+        if (destObject.Properties.TryGetValue(prop.EPC, out var property)) {
+          // 要求を受理した EPCに対しては、それに続く PDC に読み出したプロパティの長さを、
+          // EDT には読み出したプロパティ値を設定する
+          responsePropsForGet.Add(new(prop.EPC, property.ValueMemory));
+        }
+        else {
           hasError = true;
           // 要求を受理しなかった EPC に対しては、それに続く PDC に 0 を設定して
           // EDT はつけず、要求を受理できなかったことを示す。
           // (そのままでよい)
           responsePropsForGet.Add(new(prop.EPC));
-        }
-        else {
-          // 要求を受理した EPCに対しては、それに続く PDC に読み出したプロパティの長さを、
-          // EDT には読み出したプロパティ値を設定する
-          responsePropsForGet.Add(new(prop.EPC, property.ValueMemory));
         }
       }
     }
@@ -607,13 +607,13 @@ partial class EchonetClient
         validateValue: false // 通知された内容をそのまま格納するため、検証しない
       );
 
-      if (!accepted) {
-        hasError = true;
-      }
-      else {
+      if (accepted) {
         // ノードプロファイルのインスタンスリスト通知の場合
         if (sourceNode.NodeProfile == sourceObject && prop.EPC == 0xD5)
           _ = await ProcessReceivingInstanceListNotificationAsync(sourceNode, prop.EDT).ConfigureAwait(false);
+      }
+      else {
+        hasError = true;
       }
     }
 
@@ -681,13 +681,13 @@ partial class EchonetClient
         validateValue: false // 通知された内容をそのまま格納するため、検証しない
       );
 
-      if (!accepted) {
-        hasError = true;
-      }
-      else {
+      if (accepted) {
         // ノードプロファイルのインスタンスリスト通知の場合
         if (sourceNode.NodeProfile == sourceObject && prop.EPC == 0xD5)
           _ = await ProcessReceivingInstanceListNotificationAsync(sourceNode, prop.EDT).ConfigureAwait(false);
+      }
+      else {
+        hasError = true;
       }
 
       // EPC には通知時と同じプロパティコードを設定するが、

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
@@ -1176,7 +1176,7 @@ partial class EchonetClient
 
     logger?.LogDebug("Acquired (Node: {NodeAddress}, EOJ: {EOJ})", sourceNode.Address, device.EOJ);
 
-    foreach (var p in device.Properties.OrderBy(static p => p.Code)) {
+    foreach (var (_, p) in device.Properties.OrderBy(static pair => pair.Key)) {
       logger?.LogDebug(
         "Node: {NodeAddress} EOJ: {EOJ}, EPC: {EPC:X2}, Access Rule: {CanSet}/{CanGet}/{CanAnnounceStatusChange}",
         sourceNode.Address,

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
@@ -251,14 +251,14 @@ partial class EchonetClient
 
         var props = value.Message.GetProperties();
 
-        foreach (var prop in props) {
-          // 一部成功した書き込みを反映
-          var target = destinationObject.Properties.First(p => p.Code == prop.EPC);
-
-          if (prop.PDC == 0x00) {
-            // 書き込み成功
-            target.SetValue(properties.First(p => p.Code == prop.EPC).ValueMemory);
-          }
+        // 一部成功した書き込みを反映
+        foreach (var prop in props.Where(static p => p.PDC == 0)) {
+          _ = destinationObject.StorePropertyValue(
+            esv: value.Message.ESV,
+            tid: value.TID,
+            value: ConvertToPropertyValue(properties.First(p => p.Code == prop.EPC)),
+            validateValue: false // Setした内容をそのまま格納するため、検証しない
+          );
         }
 
         responseTCS.SetResult(props);
@@ -272,11 +272,13 @@ partial class EchonetClient
 
     Format1MessageReceived += HandleSetISNA;
 
+    var tid = GetNewTid();
+
     await SendFrameAsync(
       destinationNode?.Address,
       buffer => FrameSerializer.SerializeEchonetLiteFrameFormat1(
         buffer: buffer,
-        tid: GetNewTid(),
+        tid: tid,
         sourceObject: sourceObject.EOJ,
         destinationObject: destinationObject.EOJ,
         esv: ESV.SetI,
@@ -292,10 +294,14 @@ partial class EchonetClient
     }
     catch (Exception ex) {
       if (ex is OperationCanceledException exOperationCanceled && cancellationToken.Equals(exOperationCanceled.CancellationToken)) {
-        foreach (var prop in properties) {
-          var target = destinationObject.Properties.First(p => p.Code == prop.Code);
-          // 成功した書き込みを反映(全部OK)
-          target.SetValue(prop.ValueMemory);
+        // 成功した書き込みを反映(全部OK)
+        foreach (var prop in properties.Select(ConvertToPropertyValue)) {
+          _ = destinationObject.StorePropertyValue(
+            esv: ESV.SetI,
+            tid: tid,
+            value: prop,
+            validateValue: false // Setした内容をそのまま格納するため、検証しない
+          );
         }
       }
 
@@ -372,14 +378,14 @@ partial class EchonetClient
 
         var props = value.Message.GetProperties();
 
-        foreach (var prop in props) {
-          // 成功した書き込みを反映
-          var target = destinationObject.Properties.First(p => p.Code == prop.EPC);
-
-          if (prop.PDC == 0x00) {
-            // 書き込み成功
-            target.SetValue(properties.First(p => p.Code == prop.EPC).ValueMemory);
-          }
+        // 成功した書き込みを反映
+        foreach (var prop in props.Where(static p => p.PDC == 0)) {
+          _ = destinationObject.StorePropertyValue(
+            esv: value.Message.ESV,
+            tid: value.TID,
+            value: ConvertToPropertyValue(properties.First(p => p.Code == prop.EPC)),
+            validateValue: false // Setした内容をそのまま格納するため、検証しない
+          );
         }
 
         responseTCS.SetResult((value.Message.ESV == ESV.SetResponse, props));
@@ -571,13 +577,14 @@ partial class EchonetClient
 
         var props = value.Message.GetProperties();
 
-        foreach (var prop in props) {
-          // 成功した読み込みを反映
-          var target = destinationObject.Properties.First(p => p.Code == prop.EPC);
-          if (prop.PDC != 0x00) {
-            // 読み込み成功
-            target.SetValue(value.Message.ESV, value.TID, prop);
-          }
+        // 成功した読み込みを反映
+        foreach (var prop in props.Where(static p => 0 < p.PDC)) {
+          _ = destinationObject.StorePropertyValue(
+            esv: value.Message.ESV,
+            tid: value.TID,
+            value: prop,
+            validateValue: false // Getされた内容をそのまま格納するため、検証しない
+          );
         }
 
         responseTCS.SetResult((value.Message.ESV == ESV.GetResponse, props));
@@ -689,24 +696,24 @@ partial class EchonetClient
 
         var (propsForSet, propsForGet) = value.Message.GetPropertiesForSetAndGet();
 
-        foreach (var prop in propsForSet) {
-          // 成功した書き込みを反映
-          var target = destinationObject.Properties.First(p => p.Code == prop.EPC);
-
-          if (prop.PDC == 0x00) {
-            // 書き込み成功
-            target.SetValue(propertiesSet.First(p => p.Code == prop.EPC).ValueMemory);
-          }
+        // 成功した書き込みを反映
+        foreach (var prop in propsForSet.Where(static p => p.PDC == 0)) {
+          _ = destinationObject.StorePropertyValue(
+            esv: value.Message.ESV,
+            tid: value.TID,
+            value: ConvertToPropertyValue(propertiesSet.First(p => p.Code == prop.EPC)),
+            validateValue: false // Setした内容をそのまま格納するため、検証しない
+          );
         }
 
-        foreach (var prop in propsForGet) {
-          // 成功した読み込みを反映
-          var target = destinationObject.Properties.First(p => p.Code == prop.EPC);
-
-          if (prop.PDC != 0x00) {
-            // 読み込み成功
-            target.SetValue(value.Message.ESV, value.TID, prop);
-          }
+        // 成功した読み込みを反映
+        foreach (var prop in propsForGet.Where(static p => 0 < p.PDC)) {
+          _ = destinationObject.StorePropertyValue(
+            esv: value.Message.ESV,
+            tid: value.TID,
+            value: prop,
+            validateValue: false // Getされた内容をそのまま格納するため、検証しない
+          );
         }
 
         responseTCS.SetResult((value.Message.ESV == ESV.SetGetResponse, propsForSet, propsForGet));

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
@@ -45,7 +45,7 @@ partial class EchonetClient
   {
     // インスタンスリスト通知 0xD5 (TODO: refer EchonetNodeProfileDetail)
     const int SizeMax = 253; // unsigned char×(MAX)253
-    var property = SelfNode.NodeProfile.AnnoProperties.First(static p => p.Code == 0xD5);
+    var property = SelfNode.NodeProfile.Properties[0xD5];
     byte[]? buffer = null;
 
     try {

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
@@ -154,9 +154,9 @@ public abstract partial class EchonetObject {
   /// または<paramref name="validateValue"/>の指定による検証の結果、詳細仕様での規定に即していない値の場合は<see langword="false"/>。
   /// それ以外の場合は、<see langword="true"/>。
   /// </returns>
-  protected internal abstract bool StorePropertyValue(
+  internal abstract bool StorePropertyValue(
     ESV esv,
-    int tid,
+    ushort tid,
     PropertyValue value,
     bool validateValue
   );

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
@@ -89,24 +89,26 @@ public abstract partial class EchonetObject {
   );
 
   /// <summary>
-  /// プロパティの一覧
+  /// ECHONET プロパティを規定するコード(EPC)を表す<see cref="byte"/>型の値をキーとして、
+  /// それに対応するEchonetPropertyを格納する読み取り専用のディクショナリを表す
+  /// <see cref="IReadOnlyDictionary{Byte,EchonetProperty}"/>を取得します。
   /// </summary>
-  public abstract IReadOnlyCollection<EchonetProperty> Properties { get; }
+  public abstract IReadOnlyDictionary<byte, EchonetProperty> Properties { get; }
 
   /// <summary>
   /// GETプロパティの一覧
   /// </summary>
-  public virtual IEnumerable<EchonetProperty> GetProperties => Properties.Where(static p => p.CanGet);
+  public virtual IEnumerable<EchonetProperty> GetProperties => Properties.Values.Where(static p => p.CanGet);
 
   /// <summary>
   /// SETプロパティの一覧
   /// </summary>
-  public virtual IEnumerable<EchonetProperty> SetProperties => Properties.Where(static p => p.CanSet);
+  public virtual IEnumerable<EchonetProperty> SetProperties => Properties.Values.Where(static p => p.CanSet);
 
   /// <summary>
   /// ANNOプロパティの一覧
   /// </summary>
-  public virtual IEnumerable<EchonetProperty> AnnoProperties => Properties.Where(static p => p.CanAnnounceStatusChange);
+  public virtual IEnumerable<EchonetProperty> AnnoProperties => Properties.Values.Where(static p => p.CanAnnounceStatusChange);
 
   /// <summary>
   /// このオブジェクトが属するECHONET Liteノードを指定せずにインスタンスを作成します。

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
@@ -133,4 +133,45 @@ public abstract partial class EchonetObject {
 
   private protected void OnPropertiesChanged(NotifyCollectionChangedEventArgs e)
     => EventInvoker.InvokeEvent(this, PropertiesChanged, e);
+
+  /// <summary>
+  /// ECHONET サービスによって確定したECHONET プロパティの値を<see cref="EchonetProperty"/>に格納します。
+  /// </summary>
+  /// <remarks>
+  ///   <para>
+  ///     このメソッドでは、<see cref="PropertyValue"/>で与えられるプロパティ値を<see cref="EchonetProperty"/>に格納します。
+  ///     このとき、格納対象となる<see cref="EchonetProperty"/>が存在しない場合は、作成して追加します。
+  ///     ただし、指定されたECHONET プロパティ(EPC)が詳細仕様として規定されていない場合は、
+  ///     <see cref="EchonetProperty"/>の作成は行いません。
+  ///     また、<paramref name="validateValue"/>の指定による検証の結果、詳細仕様の規定に違反する値と判断される場合は、
+  ///     値の格納は行いません。
+  ///   </para>
+  ///   <para>
+  ///     このメソッドは、Setアクセスの結果として設定されるプロパティ値を格納する場合にも呼び出されるため、
+  ///     対象の<see cref="EchonetProperty"/>が実際にSetアクセス可能かどうかは考慮しません。
+  ///   </para>
+  /// </remarks>
+  /// <param name="esv">
+  /// このプロパティ値を設定する契機となったECHONET Lite サービスを表す<see cref="ESV"/>。
+  /// </param>
+  /// <param name="tid">
+  /// このプロパティ値を設定する契機となったECHONET Lite フレームのトランザクションIDを表す<see cref="ushort"/>。
+  /// </param>
+  /// <param name="value">
+  /// ECHONET Lite サービスの処理結果として内容が確定したプロパティ値を表す<see cref="PropertyValue"/>。
+  /// </param>
+  /// <param name="validateValue">
+  /// 格納される値が、詳細仕様での規定に即しているか検証するかどうかを指定する<see cref="bool"/>値。
+  /// </param>
+  /// <returns>
+  /// 格納対象となるECHONET プロパティ(EPC)が詳細仕様として規定されていない場合、
+  /// または<paramref name="validateValue"/>の指定による検証の結果、詳細仕様での規定に即していない値の場合は<see langword="false"/>。
+  /// それ以外の場合は、<see langword="true"/>。
+  /// </returns>
+  protected internal abstract bool StorePropertyValue(
+    ESV esv,
+    int tid,
+    PropertyValue value,
+    bool validateValue
+  );
 }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
 
 using Smdn.Net.EchonetLite.ComponentModel;
 using Smdn.Net.EchonetLite.Protocol;
@@ -94,21 +93,6 @@ public abstract partial class EchonetObject {
   /// <see cref="IReadOnlyDictionary{Byte,EchonetProperty}"/>を取得します。
   /// </summary>
   public abstract IReadOnlyDictionary<byte, EchonetProperty> Properties { get; }
-
-  /// <summary>
-  /// GETプロパティの一覧
-  /// </summary>
-  public virtual IEnumerable<EchonetProperty> GetProperties => Properties.Values.Where(static p => p.CanGet);
-
-  /// <summary>
-  /// SETプロパティの一覧
-  /// </summary>
-  public virtual IEnumerable<EchonetProperty> SetProperties => Properties.Values.Where(static p => p.CanSet);
-
-  /// <summary>
-  /// ANNOプロパティの一覧
-  /// </summary>
-  public virtual IEnumerable<EchonetProperty> AnnoProperties => Properties.Values.Where(static p => p.CanAnnounceStatusChange);
 
   /// <summary>
   /// このオブジェクトが属するECHONET Liteノードを指定せずにインスタンスを作成します。

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
@@ -199,7 +199,7 @@ public abstract class EchonetProperty {
       write: writer => writer.Write(newValue.EDT.Span),
       newValueSize: newValue.PDC,
       raiseValueChangedEvent: true,
-      setLastUpdatedTime: true
+      setLastUpdatedTime: true // TODO: switch by esv
     );
 
   /// <summary>

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/ReadOnlyEchonetPropertyDictionary.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/ReadOnlyEchonetPropertyDictionary.cs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Smdn.Net.EchonetLite;
+
+/// <summary>
+/// Wraps a concrete-typed dictionary of <typeparamref name="TEchonetProperty"/> to
+/// provide an implementation of a read-only dictionary interface of an abstract type <see cref="EchonetProperty"/>.
+/// </summary>
+#pragma warning disable IDE0055
+internal sealed class ReadOnlyEchonetPropertyDictionary<TEchonetProperty> :
+  IReadOnlyDictionary<byte, EchonetProperty>
+  where TEchonetProperty : notnull, EchonetProperty
+{
+#pragma warning disable IDE0055
+  private readonly IReadOnlyDictionary<byte, TEchonetProperty> concreteTypeDictionary;
+
+  public EchonetProperty this[byte key] => concreteTypeDictionary[key];
+  public IEnumerable<byte> Keys => concreteTypeDictionary.Keys;
+  public IEnumerable<EchonetProperty> Values => concreteTypeDictionary.Values;
+  public int Count => concreteTypeDictionary.Count;
+
+  internal ReadOnlyEchonetPropertyDictionary(IReadOnlyDictionary<byte, TEchonetProperty> concreteTypeDictionary)
+  {
+    this.concreteTypeDictionary = concreteTypeDictionary ?? throw new ArgumentNullException(nameof(concreteTypeDictionary));
+  }
+
+  public bool ContainsKey(byte key)
+    => concreteTypeDictionary.ContainsKey(key);
+
+  public bool TryGetValue(
+    byte key,
+    [NotNullWhen(true)] out EchonetProperty value
+  )
+  {
+    value = default!;
+
+    if (concreteTypeDictionary.TryGetValue(key, out var ret)) {
+      value = ret;
+      return true;
+    }
+
+    return false;
+  }
+
+  IEnumerator IEnumerable.GetEnumerator()
+    => GetEnumerator();
+
+  public IEnumerator<KeyValuePair<byte, EchonetProperty>> GetEnumerator()
+  {
+    foreach (var (key, value) in concreteTypeDictionary) {
+      yield return KeyValuePair.Create<byte, EchonetProperty>(key, value);
+    }
+  }
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetObject.cs
@@ -52,9 +52,9 @@ internal sealed class UnspecifiedEchonetObject : EchonetObject {
     OnPropertiesChanged(new(NotifyCollectionChangedAction.Reset));
   }
 
-  protected internal override bool StorePropertyValue(
+  internal override bool StorePropertyValue(
     ESV esv,
-    int tid,
+    ushort tid,
     PropertyValue value,
     bool validateValue
   )
@@ -92,7 +92,7 @@ internal sealed class UnspecifiedEchonetObject : EchonetObject {
     // 詳細仕様が未解決・不明なため、プロパティ値の検証はできない
     // if (validateValue) { }
 
-    property.SetValue(esv, unchecked((ushort)tid), value);
+    property.SetValue(esv, tid, value);
 
     return true;
   }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetObject.cs
@@ -5,7 +5,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
 
 using Microsoft.Extensions.Logging;
 
@@ -27,9 +26,6 @@ internal sealed class UnspecifiedEchonetObject : EchonetObject {
   private readonly ReadOnlyEchonetPropertyDictionary<UnspecifiedEchonetProperty> readOnlyPropertiesView;
 
   public override IReadOnlyDictionary<byte, EchonetProperty> Properties => readOnlyPropertiesView;
-  public override IEnumerable<EchonetProperty> GetProperties => Properties.Values.Where(static p => p.CanGet);
-  public override IEnumerable<EchonetProperty> SetProperties => Properties.Values.Where(static p => p.CanSet);
-  public override IEnumerable<EchonetProperty> AnnoProperties => Properties.Values.Where(static p => p.CanAnnounceStatusChange);
 
   internal UnspecifiedEchonetObject(EchonetNode node, EOJ eoj)
     : base(node)


### PR DESCRIPTION
### Description
- `EchonetObject.StorePropertyValue`を導入してEDTの格納処理を共通化すると同時に、 #37 で壊れたEDTの格納処理を回復・修正する
- あわせて
  - 各Echonetサービスの実装の修正と整理を行う
  - EchonetObjectからのECHONETプロパティのルックアップを簡略化・効率化し、同時にconcurrent collection化する
