### PR TITLE
IEchonetDeviceFactoryを導入する

### DIFF
--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
@@ -608,7 +608,7 @@ partial class EchonetClient
     var requestProps = message.GetProperties();
     var sourceObject = message.SEOJ.IsNodeProfile
       ? sourceNode.NodeProfile // ノードプロファイルからの通知の場合
-      : sourceNode.GetOrAddDevice(message.SEOJ, out objectAdded); // 未知のオブジェクト(プロパティはない状態で新規作成)
+      : sourceNode.GetOrAddDevice(deviceFactory, message.SEOJ, out objectAdded); // 未知のオブジェクト(プロパティはない状態で新規作成)
 
     if (objectAdded) {
       logger?.LogInformation(
@@ -682,7 +682,7 @@ partial class EchonetClient
     var objectAdded = false;
     var sourceObject = message.SEOJ.IsNodeProfile
       ? sourceNode.NodeProfile // ノードプロファイルからの通知の場合
-      : sourceNode.GetOrAddDevice(message.SEOJ, out objectAdded); // 未知のオブジェクト(プロパティはない状態で新規作成)
+      : sourceNode.GetOrAddDevice(deviceFactory, message.SEOJ, out objectAdded); // 未知のオブジェクト(プロパティはない状態で新規作成)
 
     if (objectAdded) {
       logger?.LogInformation(

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
@@ -1074,7 +1074,7 @@ partial class EchonetClient
     var instances = new List<EchonetObject>(capacity: instanceList.Count);
 
     foreach (var eoj in instanceList) {
-      var instance = sourceNode.GetOrAddDevice(eoj, out var added);
+      var instance = sourceNode.GetOrAddDevice(deviceFactory, eoj, out var added);
 
       instances.Add(instance);
 

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
@@ -18,6 +18,7 @@ public partial class EchonetClient : IEchonetClientService, IDisposable, IAsyncD
   private readonly bool shouldDisposeEchonetLiteHandler;
   private IEchonetLiteHandler echonetLiteHandler; // null if disposed
   private readonly ILogger? logger;
+  private readonly IEchonetDeviceFactory? deviceFactory;
 
   /// <summary>
   /// 現在の<see cref="EchonetClient"/>インスタンスが扱うECHONET Lite ノード(自ノード)を表す<see cref="SelfNode"/>を取得します。
@@ -42,7 +43,7 @@ public partial class EchonetClient : IEchonetClientService, IDisposable, IAsyncD
   TimeProvider? IEchonetClientService.TimeProvider => null; // TODO: make configurable, retrieve via IServiceProvider
 #endif
 
-  /// <inheritdoc cref="EchonetClient(EchonetNode, IEchonetLiteHandler, bool, ILogger{EchonetClient})"/>
+  /// <inheritdoc cref="EchonetClient(EchonetNode, IEchonetLiteHandler, bool, IEchonetDeviceFactory, ILogger{EchonetClient})"/>
   public EchonetClient(
     IEchonetLiteHandler echonetLiteHandler,
     ILogger<EchonetClient>? logger = null
@@ -55,7 +56,7 @@ public partial class EchonetClient : IEchonetClientService, IDisposable, IAsyncD
   {
   }
 
-  /// <inheritdoc cref="EchonetClient(EchonetNode, IEchonetLiteHandler, bool, ILogger{EchonetClient})"/>
+  /// <inheritdoc cref="EchonetClient(EchonetNode, IEchonetLiteHandler, bool, IEchonetDeviceFactory, ILogger{EchonetClient})"/>
   /// <exception cref="ArgumentNullException">
   /// <paramref name="echonetLiteHandler"/>が<see langword="null"/>です。
   /// </exception>
@@ -68,6 +69,7 @@ public partial class EchonetClient : IEchonetClientService, IDisposable, IAsyncD
       selfNode: EchonetNode.CreateSelfNode(devices: Array.Empty<EchonetObject>()),
       echonetLiteHandler: echonetLiteHandler ?? throw new ArgumentNullException(nameof(echonetLiteHandler)),
       shouldDisposeEchonetLiteHandler: shouldDisposeEchonetLiteHandler,
+      deviceFactory: null,
       logger: logger
     )
   {
@@ -79,6 +81,7 @@ public partial class EchonetClient : IEchonetClientService, IDisposable, IAsyncD
   /// <param name="selfNode">自ノードを表す<see cref="EchonetNode"/>。</param>
   /// <param name="echonetLiteHandler">このインスタンスがECHONET Lite フレームを送受信するために使用する<see cref="IEchonetLiteHandler"/>。</param>
   /// <param name="shouldDisposeEchonetLiteHandler">オブジェクトが破棄される際に、<paramref name="echonetLiteHandler"/>も破棄するかどうかを表す値。</param>
+  /// <param name="deviceFactory">機器オブジェクトのファクトリとして使用される<see cref="IEchonetDeviceFactory"/>。</param>
   /// <param name="logger">このインスタンスの動作を記録する<see cref="ILogger{EchonetClient}"/>。</param>
   /// <exception cref="ArgumentNullException">
   /// <paramref name="selfNode"/>が<see langword="null"/>です。
@@ -88,6 +91,7 @@ public partial class EchonetClient : IEchonetClientService, IDisposable, IAsyncD
     EchonetNode selfNode,
     IEchonetLiteHandler echonetLiteHandler,
     bool shouldDisposeEchonetLiteHandler,
+    IEchonetDeviceFactory? deviceFactory,
     ILogger<EchonetClient>? logger
   )
   {
@@ -95,6 +99,7 @@ public partial class EchonetClient : IEchonetClientService, IDisposable, IAsyncD
     this.shouldDisposeEchonetLiteHandler = shouldDisposeEchonetLiteHandler;
     this.echonetLiteHandler = echonetLiteHandler ?? throw new ArgumentNullException(nameof(echonetLiteHandler));
     this.echonetLiteHandler.Received += EchonetDataReceived;
+    this.deviceFactory = deviceFactory;
 
     SelfNode = selfNode ?? throw new ArgumentNullException(nameof(selfNode));
     SelfNode.Owner = this;

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetDevice.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetDevice.cs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+#pragma warning disable CA1848 // CA1848: パフォーマンスを向上させるには、LoggerMessage デリゲートを使用します -->
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+using Microsoft.Extensions.Logging;
+
+using Smdn.Net.EchonetLite.Protocol;
+
+namespace Smdn.Net.EchonetLite;
+
+/// <summary>
+/// 明示的に型付けされた機器オブジェクトを表す<see cref="EchonetObject"/>を実装するための基底クラスです。
+/// </summary>
+/// <remarks>
+/// このクラスは、<see cref="IEchonetDeviceFactory.Create(byte, byte, byte)"/>メソッドの戻り値として使用されます。
+/// 他ノードの機器オブジェクトを明示的に型付けされたオブジェクトとして扱う場合は、このクラスを拡張してください。
+/// </remarks>
+/// <seealso cref="IEchonetDeviceFactory"/>
+/// <seealso href="https://echonet.jp/spec_v114_lite/">
+/// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ２．２ 機器オブジェクト
+/// </seealso>
+public class EchonetDevice : EchonetObject {
+  public override bool HasPropertyMapAcquired { get; internal set; }
+  public override byte ClassGroupCode { get; }
+  public override byte ClassCode { get; }
+  public override byte InstanceCode { get; }
+
+  private readonly ConcurrentDictionary<byte, EchonetProperty> properties;
+  private readonly ReadOnlyEchonetPropertyDictionary<EchonetProperty> readOnlyPropertiesView;
+
+  public override IReadOnlyDictionary<byte, EchonetProperty> Properties => readOnlyPropertiesView;
+
+  public EchonetDevice(
+    byte classGroupCode,
+    byte classCode,
+    byte instanceCode
+  )
+  {
+    ClassGroupCode = classGroupCode;
+    ClassCode = classCode;
+    InstanceCode = instanceCode;
+
+    properties = new(
+      concurrencyLevel: ConcurrentDictionaryUtils.DefaultConcurrencyLevel, // default
+      capacity: 20 // TODO: best initial capacity
+    );
+    readOnlyPropertiesView = new(properties);
+  }
+
+  /// <summary>
+  /// 指定されたプロパティコードを持つ<see cref="EchonetProperty"/>インスタンスを作成する。
+  /// </summary>
+  /// <param name="propertyCode">作成するプロパティのコード。</param>
+  /// <returns>
+  /// 作成された<see cref="EchonetProperty"/>インスタンス。
+  /// </returns>
+  protected virtual EchonetProperty CreateProperty(
+    byte propertyCode
+  )
+    => CreateProperty(
+      propertyCode: propertyCode,
+      // すべてのアクセスが可能なプロパティと仮定してインスタンスを作成する
+      canSet: true,
+      canGet: true,
+      canAnnounceStatusChange: true
+    );
+
+  /// <summary>
+  /// 指定されたプロパティコードおよびアクセシビリティを持つ<see cref="EchonetProperty"/>インスタンスを作成する。
+  /// </summary>
+  /// <param name="propertyCode">作成するプロパティのコード。</param>
+  /// <param name="canSet">作成するプロパティのSetアクセス可否を表す<see cref="bool"/>。</param>
+  /// <param name="canGet">作成するプロパティのGetアクセス可否を表す<see cref="bool"/>。</param>
+  /// <param name="canAnnounceStatusChange">作成するプロパティのAnnoアクセス可否を表す<see cref="bool"/>。</param>
+  /// <returns>
+  /// 作成された<see cref="EchonetProperty"/>インスタンス。
+  /// </returns>
+  protected virtual EchonetProperty CreateProperty(
+    byte propertyCode,
+    bool canSet,
+    bool canGet,
+    bool canAnnounceStatusChange
+  )
+    => new UnspecifiedEchonetProperty(
+      device: this,
+      code: propertyCode,
+      canSet: canSet,
+      canGet: canGet,
+      canAnnounceStatusChange: canAnnounceStatusChange
+    );
+
+  internal override void ApplyPropertyMap(
+    IEnumerable<(byte Code, bool CanSet, bool CanGet, bool CanAnnounceStatusChange)> propertyMap
+  )
+  {
+    if (propertyMap is null)
+      throw new ArgumentNullException(nameof(propertyMap));
+
+    properties.Clear();
+
+    foreach (var (code, canSet, canGet, canAnnounceStatusChange) in propertyMap) {
+      _ = properties.TryAdd(code, CreateProperty(code, canSet, canGet, canAnnounceStatusChange));
+    }
+
+    OnPropertiesChanged(new(NotifyCollectionChangedAction.Reset));
+  }
+
+  internal override bool StorePropertyValue(
+    ESV esv,
+    ushort tid,
+    PropertyValue value,
+    bool validateValue
+  )
+  {
+    if (!properties.TryGetValue(value.EPC, out var property)) {
+      // 未知のプロパティのため、新規作成して追加する
+      property = CreateProperty(value.EPC);
+
+      var p = properties.GetOrAdd(property.Code, property);
+
+      if (ReferenceEquals(p, property)) {
+        Node.Owner?.Logger?.LogInformation(
+          "New property added (Node: {NodeAddress}, EOJ: {EOJ}, EPC: {EPC:X2})",
+          Node.Address,
+          EOJ,
+          property.Code
+        );
+
+        OnPropertiesChanged(
+          new(
+            action: NotifyCollectionChangedAction.Add,
+            changedItem: property
+          )
+        );
+      }
+    }
+
+    if (validateValue && !property.IsAcceptableValue(value.EDT.Span))
+      return false;
+
+    property.SetValue(esv, tid, value);
+
+    return true;
+  }
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
@@ -11,8 +11,14 @@ using Smdn.Net.EchonetLite.Protocol;
 namespace Smdn.Net.EchonetLite;
 
 /// <summary>
-/// ECHONET Lite オブジェクトインスタンス
+/// ECHONET オブジェクトを表し、その機能に関するAPIを提供する抽象クラスです。
+/// このクラスは、機器オブジェクトおよびプロファイルオブジェクトを表現します。
 /// </summary>
+/// <seealso href="https://echonet.jp/spec_v114_lite/">
+/// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 第２章 ECHONET オブジェクト
+/// </seealso>
+/// <seealso cref="EchonetNode.Devices"/>
+/// <seealso cref="EchonetDevice"/>
 public abstract partial class EchonetObject {
   public static EchonetObject Create(IEchonetObjectSpecification objectDetail, byte instanceCode)
     => new DetailedEchonetObject(
@@ -33,18 +39,20 @@ public abstract partial class EchonetObject {
   /// <summary>
   /// このオブジェクトが属するECHONET Liteノードを表す<see cref="EchonetNode"/>を取得します。
   /// </summary>
-  public EchonetNode Node {
-    get {
-#if DEBUG
-      if (OwnerNode is null)
-        throw new InvalidOperationException($"{nameof(OwnerNode)} is null");
-#endif
+  public EchonetNode Node => OwnerNode;
 
-      return OwnerNode!;
-    }
+  internal EchonetNode OwnerNode {
+#if false // requires semi-auto properties
+    get => field ?? throw new InvalidOperationException($"{nameof(OwnerNode)} is not set to a valid value.");
+    set => field = value ?? throw new InvalidOperationException($"{nameof(OwnerNode)} can not be null");
+  }
+#else
+    get => ownerNode ?? throw new InvalidOperationException($"{nameof(OwnerNode)} is not set to a valid value.");
+    set => ownerNode = value ?? throw new InvalidOperationException($"{nameof(OwnerNode)} can not be null.");
   }
 
-  internal EchonetNode? OwnerNode { get; set; }
+  private EchonetNode? ownerNode;
+#endif
 
   /// <summary>
   /// このインスタンスでイベントを発生させるために使用される<see cref="IEventInvoker"/>を取得します。
@@ -95,26 +103,14 @@ public abstract partial class EchonetObject {
   public abstract IReadOnlyDictionary<byte, EchonetProperty> Properties { get; }
 
   /// <summary>
-  /// このオブジェクトが属するECHONET Liteノードを指定せずにインスタンスを作成します。
+  /// 任意のECHONET オブジェクトを表す<see cref="EchonetObject"/>インスタンスを作成します。
   /// </summary>
   /// <remarks>
-  /// このコンストラクタを使用してインスタンスを作成した場合、インスタンスが使用されるまでの間に、
-  /// <see cref="OwnerNode"/>プロパティへ明示的に<see cref="EchonetNode"/>を設定する必要があります。
+  /// このコンストラクタを使用してインスタンスを作成したあと、インスタンスが使用されるまでの間に、
+  /// <see cref="OwnerNode"/>プロパティへ明示的に<see cref="EchonetNode"/>を設定してください。
   /// </remarks>
   private protected EchonetObject()
   {
-  }
-
-  /// <summary>
-  /// このオブジェクトが属するECHONET Liteノードを指定してインスタンスを作成します。
-  /// </summary>
-  /// <param name="node">このオブジェクトが属するECHONET Liteノードを表す<see cref="EchonetNode"/>を指定します。</param>
-  /// <exception cref="ArgumentNullException">
-  /// <paramref name="node"/>が<see langword="null"/>です。
-  /// </exception>
-  private protected EchonetObject(EchonetNode node)
-  {
-    OwnerNode = node ?? throw new ArgumentNullException(nameof(node));
   }
 
   /// <summary>

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/IEchonetDeviceFactory.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/IEchonetDeviceFactory.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+namespace Smdn.Net.EchonetLite;
+
+/// <summary>
+/// 指定されたコードに対応する機器オブジェクトを作成するための機能を提供するためのインターフェイスです。
+/// このインターフェイスは、他ノードの機器オブジェクトを独自に定義したクラスとして型付けして扱う場合に使用します。
+/// </summary>
+/// <seealso cref="EchonetDevice"/>
+/// <seealso cref="EchonetOtherNode.Devices"/>
+public interface IEchonetDeviceFactory {
+  /// <summary>
+  /// 指定されたコードに対応する機器オブジェクトを表す<see cref="EchonetDevice"/>を作成します。
+  /// </summary>
+  /// <param name="classGroupCode">作成する機器オブジェクトのクラスグループコード。</param>
+  /// <param name="classCode">作成する機器オブジェクトのクラスコード。</param>
+  /// <param name="instanceCode">作成する機器オブジェクトのインスタンスコード。</param>
+  /// <returns>作成した<see cref="EchonetDevice"/>インスタンス。</returns>
+  EchonetDevice? Create(
+    byte classGroupCode,
+    byte classCode,
+    byte instanceCode
+  );
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetObject.cs
@@ -27,8 +27,7 @@ internal sealed class UnspecifiedEchonetObject : EchonetObject {
 
   public override IReadOnlyDictionary<byte, EchonetProperty> Properties => readOnlyPropertiesView;
 
-  internal UnspecifiedEchonetObject(EchonetNode node, EOJ eoj)
-    : base(node)
+  internal UnspecifiedEchonetObject(EOJ eoj)
   {
     ClassGroupCode = eoj.ClassGroupCode;
     ClassCode = eoj.ClassCode;


### PR DESCRIPTION
### Description
現在の実装では、発見された他ノードの機器オブジェクトは、既定かつ固定で非公開型の`EchonetObject`派生クラスで表現される。

`IEchonetDeviceFactory`を導入することにより、機器オブジェクトの作成を行うファクトリメソッドを実装できるようにし、
また`EchonetClient`が他ノードの機器オブジェクトのインスタンスを作成する際にそれを使用できるようにする。

これにより、発見された他ノードの機器オブジェクトのクラスグループコード・クラスコードに合わせた具象型を作成するなどを可能にする。

本PRでは同時に`IEchonetDeviceFactory`で作成される機器オブジェクト型の基底クラスとして`EchonetDevice`も追加する。