### PR TITLE
ECHONETサービス要求のAPIを整理する

### DIFF
--- a/src/Common/Shim/System.Threading.Tasks/TaskCompletionSource.cs
+++ b/src/Common/Shim/System.Threading.Tasks/TaskCompletionSource.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+#pragma warning disable CA1812
+
+#if !NET5_0_OR_GREATER
+namespace System.Threading.Tasks;
+
+internal class TaskCompletionSource : TaskCompletionSource<TaskCompletionSource.Void> {
+  public readonly struct Void { }
+
+  public new Task Task => base.Task;
+
+  public void SetResult()
+    => SetResult(default);
+
+  public bool TrySetResult()
+    => TrySetResult(default);
+}
+#endif

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/EOJ.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.Protocol/EOJ.cs
@@ -10,6 +10,15 @@ namespace Smdn.Net.EchonetLite.Protocol;
 /// </summary>
 public readonly struct EOJ : IEquatable<EOJ> {
   /// <summary>
+  /// ノードプロファイルを表す<see cref="EOJ"/>を取得します。　インスタンスコードは<c>0</c>を使用します。
+  /// </summary>
+  public static readonly EOJ NodeProfile = new(
+    classGroupCode: Codes.ClassGroups.ProfileClass,
+    classCode: Codes.Classes.NodeProfile,
+    instanceCode: 0x00
+  );
+
+  /// <summary>
   /// クラスグループコード
   /// </summary>
   public byte ClassGroupCode { get; }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.csproj
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.csproj
@@ -38,6 +38,7 @@ SPDX-License-Identifier: MIT
 
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)..\Common\Shim\System.Runtime.CompilerServices\IsExternalInit.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)..\Common\Shim\System.Threading.Tasks\TaskCompletionSource.cs"/>
   </ItemGroup>
 
   <Target Name="GenerateReadmeFileContent">

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/DetailedEchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/DetailedEchonetObject.cs
@@ -69,7 +69,8 @@ internal sealed class DetailedEchonetObject : EchonetObject {
     ESV esv,
     ushort tid,
     PropertyValue value,
-    bool validateValue
+    bool validateValue,
+    bool? newModificationState
   )
   {
     if (!properties.TryGetValue(value.EPC, out var property))
@@ -80,7 +81,7 @@ internal sealed class DetailedEchonetObject : EchonetObject {
       // 詳細仕様の規定に違反する値のため、格納しない
       return false;
 
-    property.SetValue(esv, tid, value);
+    property.SetValue(esv, tid, value, newModificationState);
 
     return true;
   }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
@@ -195,7 +195,7 @@ partial class EchonetClient
     ).ConfigureAwait(false);
 
     // 不可応答は無視
-    if (!result) {
+    if (!result.IsSuccess) {
       logger?.LogWarning("Service not available (Node: {NodeAddress}, EOJ: {EOJ})", otherNode.Address, device.EOJ);
       return false;
     }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
@@ -29,7 +29,7 @@ partial class EchonetClient
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４．３．１ ECHONET Lite ノードスタート時の基本シーケンス
   /// </seealso>
-  public async ValueTask PerformInstanceListNotificationAsync(
+  public async ValueTask NotifyInstanceListAsync(
     CancellationToken cancellationToken = default
   )
   {
@@ -87,7 +87,7 @@ partial class EchonetClient
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４．２．１ サービス内容に関する基本シーケンス （C）通知要求受信時の基本シーケンス
   /// </seealso>
-  public async Task PerformInstanceListNotificationRequestAsync<TState>(
+  public async Task RequestNotifyInstanceListAsync<TState>(
     Func<EchonetNode, TState, bool> onInstanceListUpdated,
     TState state,
     CancellationToken cancellationToken = default
@@ -116,7 +116,7 @@ partial class EchonetClient
       if (onInstanceListUpdated is not null)
         InstanceListUpdated += HandleInstanceListUpdated;
 
-      await PerformInstanceListNotificationRequestAsync(cancellationToken).ConfigureAwait(false);
+      await RequestNotifyInstanceListAsync(cancellationToken).ConfigureAwait(false);
 
       // イベントの発生およびコールバックの処理を待機する
       _ = await tcs.Task.ConfigureAwait(false);
@@ -136,7 +136,7 @@ partial class EchonetClient
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４．２．１ サービス内容に関する基本シーケンス （C）通知要求受信時の基本シーケンス
   /// </seealso>
-  public ValueTask PerformInstanceListNotificationRequestAsync(
+  public ValueTask RequestNotifyInstanceListAsync(
     CancellationToken cancellationToken = default
   )
     // インスタンスリスト通知要求

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
@@ -63,7 +63,7 @@ partial class EchonetClient
     // インスタンスリスト通知
     // > ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
     // > 自発的「通知」の場合は、DEOJに特に明示的に指定する EOJ がない場合は、ノードプロファイルクラスを格納することとする。
-    await PerformPropertyValueNotificationAsync(
+    await NotifyOneWayAsync(
       SelfNode.NodeProfile.EOJ, // ノードプロファイルから
       Enumerable.Repeat(new PropertyValue(property.Code, property.ValueMemory), 1),
       null, // 一斉通知
@@ -142,7 +142,7 @@ partial class EchonetClient
     // インスタンスリスト通知要求
     // > ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
     // > 自発的「通知」の場合は、DEOJに特に明示的に指定する EOJ がない場合は、ノードプロファイルクラスを格納することとする。
-    => PerformPropertyValueNotificationRequestAsync(
+    => RequestNotifyOneWayAsync(
       SelfNode.NodeProfile.EOJ, // ノードプロファイルから
       null, // 一斉通知
       SelfNode.NodeProfile.EOJ, // 具体的なDEOJがないので、代わりにノードプロファイルを指定する
@@ -186,7 +186,7 @@ partial class EchonetClient
 
     OnPropertyMapAcquiring(otherNode, device);
 
-    var result = await PerformPropertyValueReadRequestAsync(
+    var result = await RequestReadAsync(
       sourceObject: SelfNode.NodeProfile.EOJ,
       destinationNodeAddress: otherNode.Address,
       destinationObject: device.EOJ,

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
@@ -269,7 +269,8 @@ partial class EchonetClient
         esv: ESV.SetI,
         tid: tid,
         value: prop,
-        validateValue: true // Setされる内容を検証する
+        validateValue: true, // Setされる内容を検証する
+        newModificationState: false // Setされた内容が格納されるため、値を未変更状態にする
       );
 
       if (accepted) {
@@ -347,7 +348,8 @@ partial class EchonetClient
           esv: ESV.SetC,
           tid: tid,
           value: prop,
-          validateValue: true // Setされる内容を検証する
+          validateValue: true, // Setされる内容を検証する
+          newModificationState: false // Setされた内容が格納されるため、値を未変更状態にする
         );
 
         if (accepted) {
@@ -501,7 +503,8 @@ partial class EchonetClient
           esv: ESV.SetGet,
           tid: tid,
           value: prop,
-          validateValue: true // Setされる内容を検証する
+          validateValue: true, // Setされる内容を検証する
+          newModificationState: false // Setされた内容が格納されるため、値を未変更状態にする
         );
 
         if (accepted) {
@@ -602,7 +605,8 @@ partial class EchonetClient
         esv: ESV.InfRequest,
         tid: tid,
         value: prop,
-        validateValue: false // 通知された内容をそのまま格納するため、検証しない
+        validateValue: false, // 通知された内容をそのまま格納するため、検証しない
+        newModificationState: false // 通知された内容が格納されるため、値を未変更状態にする
       );
 
       if (accepted) {
@@ -676,7 +680,8 @@ partial class EchonetClient
         esv: ESV.InfC,
         tid: tid,
         value: prop,
-        validateValue: false // 通知された内容をそのまま格納するため、検証しない
+        validateValue: false, // 通知された内容をそのまま格納するため、検証しない
+        newModificationState: false // 通知された内容が格納されるため、値を未変更状態にする
       );
 
       if (accepted) {

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
@@ -393,7 +393,7 @@ partial class EchonetClient
   /// <see cref="Task{T}.Result"/>には処理の結果が含まれます。
   /// 要求を正常に処理した場合は<see langword="true"/>、そうでなければ<see langword="false"/>が設定されます。
   /// </returns>
-  /// <seealso cref="PerformPropertyValueReadRequestAsync(EchonetObject, EchonetNode?, EchonetObject, IEnumerable{PropertyValue}, CancellationToken)"/>
+  /// <seealso cref="PerformPropertyValueReadRequestAsync"/>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
@@ -566,7 +566,7 @@ partial class EchonetClient
   /// <see cref="Task{T}.Result"/>には処理の結果が含まれます。
   /// 要求を正常に処理した場合は<see langword="true"/>、そうでなければ<see langword="false"/>が設定されます。
   /// </returns>
-  /// <seealso cref="PerformPropertyValueNotificationRequestAsync(EchonetObject, EchonetNode?, EchonetObject, IEnumerable{EchonetProperty}, CancellationToken)"/>
+  /// <seealso cref="PerformPropertyValueNotificationRequestAsync"/>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
@@ -91,7 +91,7 @@ partial class EchonetClient
         // なければ、プロパティ値書き込み要求不可応答 SetI_SNA
         handlerTask = handlerTaskFactory.StartNew(async () => {
           try {
-            _ = await HandlePropertyValueWriteRequestAsync(address, tid, message, destObject).ConfigureAwait(false);
+            _ = await HandleWriteOneWayAsync(address, tid, message, destObject).ConfigureAwait(false);
           }
           catch (Exception ex) {
             if (logger is not null)
@@ -107,7 +107,7 @@ partial class EchonetClient
         // なければ、プロパティ値書き込み要求不可応答 SetC_SNA
         handlerTask = handlerTaskFactory.StartNew(async () => {
           try {
-            _ = await HandlePropertyValueWriteRequestResponseRequiredAsync(address, tid, message, destObject).ConfigureAwait(false);
+            _ = await HandleWriteAsync(address, tid, message, destObject).ConfigureAwait(false);
           }
           catch (Exception ex) {
             if (logger is not null)
@@ -123,7 +123,7 @@ partial class EchonetClient
         // なければ、プロパティ値読み出し不可応答 Get_SNA
         handlerTask = handlerTaskFactory.StartNew(async () => {
           try {
-            _ = await HandlePropertyValueReadRequestAsync(address, tid, message, destObject).ConfigureAwait(false);
+            _ = await HandleReadAsync(address, tid, message, destObject).ConfigureAwait(false);
           }
           catch (Exception ex) {
             if (logger is not null)
@@ -144,7 +144,7 @@ partial class EchonetClient
         // なければ、プロパティ値書き込み・読み出し不可応答 SetGet_SNA
         handlerTask = handlerTaskFactory.StartNew(async () => {
           try {
-            _ = await HandlePropertyValueWriteReadRequestAsync(address, tid, message, destObject).ConfigureAwait(false);
+            _ = await HandleWriteReadAsync(address, tid, message, destObject).ConfigureAwait(false);
           }
           catch (Exception ex) {
             if (logger is not null)
@@ -161,7 +161,7 @@ partial class EchonetClient
         // なので、要求送信(INF_REQ)のハンドラでも対処するが、こちらでも自発として対処をする。
         handlerTask = handlerTaskFactory.StartNew(() => {
           try {
-            _ = HandlePropertyValueNotificationRequest(address, tid, message, sourceNode);
+            _ = HandleNotifyOneWay(address, tid, message, sourceNode);
           }
           catch (Exception ex) {
             if (logger is not null)
@@ -176,7 +176,7 @@ partial class EchonetClient
         // プロパティ値通知応答 INFC_Res
         handlerTask = handlerTaskFactory.StartNew(async () => {
           try {
-            _ = await HandlePropertyValueNotificationResponseRequiredAsync(address, tid, message, sourceNode, destObject).ConfigureAwait(false);
+            _ = await HandleNotifyAsync(address, tid, message, sourceNode, destObject).ConfigureAwait(false);
           }
           catch (Exception ex) {
             if (logger is not null)
@@ -239,14 +239,14 @@ partial class EchonetClient
   /// <see cref="Task{T}.Result"/>には処理の結果が含まれます。
   /// 要求を正常に処理した場合は<see langword="true"/>、そうでなければ<see langword="false"/>が設定されます。
   /// </returns>
-  /// <seealso cref="PerformPropertyValueWriteRequestAsync"/>
+  /// <seealso cref="RequestWriteOneWayAsync"/>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.１ プロパティ値書き込みサービス（応答不要）［0x60, 0x50］
   /// </seealso>
-  private async Task<bool> HandlePropertyValueWriteRequestAsync(
+  private async Task<bool> HandleWriteOneWayAsync(
     IPAddress address,
     ushort tid,
     Format1Message message,
@@ -316,14 +316,14 @@ partial class EchonetClient
   /// <see cref="Task{T}.Result"/>には処理の結果が含まれます。
   /// 要求を正常に処理した場合は<see langword="true"/>、そうでなければ<see langword="false"/>が設定されます。
   /// </returns>
-  /// <seealso cref="PerformPropertyValueWriteRequestResponseRequiredAsync"/>
+  /// <seealso cref="RequestWriteAsync"/>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.２ プロパティ値書き込みサービス（応答要）［0x61,0x71,0x51］
   /// </seealso>
-  private async Task<bool> HandlePropertyValueWriteRequestResponseRequiredAsync(
+  private async Task<bool> HandleWriteAsync(
     IPAddress address,
     ushort tid,
     Format1Message message,
@@ -393,14 +393,14 @@ partial class EchonetClient
   /// <see cref="Task{T}.Result"/>には処理の結果が含まれます。
   /// 要求を正常に処理した場合は<see langword="true"/>、そうでなければ<see langword="false"/>が設定されます。
   /// </returns>
-  /// <seealso cref="PerformPropertyValueReadRequestAsync"/>
+  /// <seealso cref="RequestReadAsync"/>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.３ プロパティ値読み出しサービス［0x62,0x72,0x52］
   /// </seealso>
-  private async Task<bool> HandlePropertyValueReadRequestAsync(
+  private async Task<bool> HandleReadAsync(
     IPAddress address,
     ushort tid,
     Format1Message message,
@@ -468,14 +468,14 @@ partial class EchonetClient
   /// <see cref="Task{T}.Result"/>には処理の結果が含まれます。
   /// 要求を正常に処理した場合は<see langword="true"/>、そうでなければ<see langword="false"/>が設定されます。
   /// </returns>
-  /// <seealso cref="PerformPropertyValueWriteReadRequestAsync"/>
+  /// <seealso cref="RequestWriteReadAsync"/>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.４ プロパティ値書き込み読み出しサービス［0x6E,0x7E,0x5E］
   /// </seealso>
-  private async Task<bool> HandlePropertyValueWriteReadRequestAsync(
+  private async Task<bool> HandleWriteReadAsync(
     IPAddress address,
     ushort tid,
     Format1Message message,
@@ -566,14 +566,14 @@ partial class EchonetClient
   /// <see cref="Task{T}.Result"/>には処理の結果が含まれます。
   /// 要求を正常に処理した場合は<see langword="true"/>、そうでなければ<see langword="false"/>が設定されます。
   /// </returns>
-  /// <seealso cref="PerformPropertyValueNotificationRequestAsync"/>
+  /// <seealso cref="RequestNotifyOneWayAsync"/>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
   /// </seealso>
-  private bool HandlePropertyValueNotificationRequest(
+  private bool HandleNotifyOneWay(
     IPAddress address,
     ushort tid,
     Format1Message message,
@@ -631,14 +631,14 @@ partial class EchonetClient
   /// <see cref="Task{T}.Result"/>には処理の結果が含まれます。
   /// 要求を正常に処理した場合は<see langword="true"/>、そうでなければ<see langword="false"/>が設定されます。
   /// </returns>
-  /// <seealso cref="PerformPropertyValueNotificationResponseRequiredAsync"/>
+  /// <seealso cref="NotifyAsync"/>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.６ プロパティ値通知(応答要)サービス［0x74, 0x7A］
   /// </seealso>
-  private async Task<bool> HandlePropertyValueNotificationResponseRequiredAsync(
+  private async Task<bool> HandleNotifyAsync(
     IPAddress address,
     ushort tid,
     Format1Message message,
@@ -716,8 +716,8 @@ partial class EchonetClient
   /// </summary>
   /// <param name="sourceNode">送信元のECHONET Lite ノードを表す<see cref="EchonetOtherNode"/>。</param>
   /// <param name="edtInstantListNotification">受信したインスタンスリスト通知を表す<see cref="ReadOnlySpan{Byte}"/>。</param>
-  /// <seealso cref="HandlePropertyValueNotificationRequest"/>
-  /// <seealso cref="HandlePropertyValueNotificationResponseRequiredAsync"/>
+  /// <seealso cref="HandleNotifyOneWay"/>
+  /// <seealso cref="HandleNotifyAsync"/>
   private bool ProcessReceivingInstanceListNotification(
     EchonetOtherNode sourceNode,
     ReadOnlyMemory<byte> edtInstantListNotification

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
@@ -35,13 +35,16 @@ partial class EchonetClient
   /// <exception cref="ArgumentNullException">
   /// <paramref name="properties"/>が<see langword="null"/>です。
   /// </exception>
+  /// <remarks>
+  /// このメソッドでは応答を待機しません。　ECHONET Lite サービスの要求を行ったら即座に処理を返します。
+  /// </remarks>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.１ プロパティ値書き込みサービス（応答不要）［0x60, 0x50］
   /// </seealso>
-  public async Task PerformPropertyValueWriteRequestAsync(
+  public async Task RequestWriteOneWayAsync(
     EOJ sourceObject,
     IPAddress? destinationNodeAddress,
     EOJ destinationObject,
@@ -158,6 +161,9 @@ partial class EchonetClient
   /// <exception cref="ArgumentNullException">
   /// <paramref name="properties"/>が<see langword="null"/>です。
   /// </exception>
+  /// <remarks>
+  /// このメソッドではECHONET Lite サービスの要求を送信したあと、応答を待機します。
+  /// </remarks>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
@@ -165,7 +171,7 @@ partial class EchonetClient
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.２ プロパティ値書き込みサービス（応答要）［0x61,0x71,0x51］
   /// </seealso>
   public async Task<bool>
-  PerformPropertyValueWriteRequestResponseRequiredAsync(
+  RequestWriteAsync(
     EOJ sourceObject,
     IPAddress? destinationNodeAddress,
     EOJ destinationObject,
@@ -267,6 +273,9 @@ partial class EchonetClient
   /// <exception cref="ArgumentNullException">
   /// <paramref name="propertyCodes"/>が<see langword="null"/>です。
   /// </exception>
+  /// <remarks>
+  /// このメソッドではECHONET Lite サービスの要求を送信したあと、応答を待機します。
+  /// </remarks>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
@@ -274,7 +283,7 @@ partial class EchonetClient
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.３ プロパティ値読み出しサービス［0x62,0x72,0x52］
   /// </seealso>
   public async Task<bool>
-  PerformPropertyValueReadRequestAsync(
+  RequestReadAsync(
     EOJ sourceObject,
     IPAddress? destinationNodeAddress,
     EOJ destinationObject,
@@ -378,6 +387,9 @@ partial class EchonetClient
   /// <paramref name="propertiesToSet"/>が<see langword="null"/>です。
   /// または、<paramref name="propertyCodesToGet"/>が<see langword="null"/>です。
   /// </exception>
+  /// <remarks>
+  /// このメソッドではECHONET Lite サービスの要求を送信したあと、応答を待機します。
+  /// </remarks>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
@@ -385,7 +397,7 @@ partial class EchonetClient
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.４ プロパティ値書き込み読み出しサービス［0x6E,0x7E,0x5E］
   /// </seealso>
   public async Task<bool>
-  PerformPropertyValueWriteReadRequestAsync(
+  RequestWriteReadAsync(
     EOJ sourceObject,
     IPAddress? destinationNodeAddress,
     EOJ destinationObject,
@@ -499,13 +511,16 @@ partial class EchonetClient
   /// <exception cref="ArgumentNullException">
   /// <paramref name="propertyCodes"/>が<see langword="null"/>です。
   /// </exception>
+  /// <remarks>
+  /// このメソッドでは応答を待機しません。　ECHONET Lite サービスの要求を行ったら即座に処理を返します。
+  /// </remarks>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
   /// </seealso>
-  public ValueTask PerformPropertyValueNotificationRequestAsync(
+  public ValueTask RequestNotifyOneWayAsync(
     EOJ sourceObject,
     IPAddress? destinationNodeAddress,
     EOJ destinationObject,
@@ -548,13 +563,16 @@ partial class EchonetClient
   /// <exception cref="ArgumentNullException">
   /// <paramref name="properties"/>が<see langword="null"/>です。
   /// </exception>
+  /// <remarks>
+  /// このメソッドでは応答を待機しません。　ECHONET Lite サービスの要求を行ったら即座に処理を返します。
+  /// </remarks>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
   /// </seealso>
-  public ValueTask PerformPropertyValueNotificationAsync(
+  public ValueTask NotifyOneWayAsync(
     EOJ sourceObject,
     IEnumerable<PropertyValue> properties,
     IPAddress? destinationNodeAddress,
@@ -599,6 +617,9 @@ partial class EchonetClient
   /// <paramref name="properties"/>が<see langword="null"/>です。
   /// または、<paramref name="destinationNodeAddress"/>が<see langword="null"/>です。
   /// </exception>
+  /// <remarks>
+  /// このメソッドではECHONET Lite サービスの要求を送信したあと、応答を待機します。
+  /// </remarks>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
   /// </seealso>
@@ -606,7 +627,7 @@ partial class EchonetClient
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.６ プロパティ値通知(応答要)サービス［0x74, 0x7A］
   /// </seealso>
   public async Task
-  PerformPropertyValueNotificationResponseRequiredAsync(
+  NotifyAsync(
     EOJ sourceObject,
     IEnumerable<PropertyValue> properties,
     IPAddress destinationNodeAddress,

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
@@ -105,8 +105,11 @@ partial class EchonetClient
             esv: value.Message.ESV,
             tid: value.TID,
             value: properties.First(p => p.EPC == prop.EPC),
-            validateValue: false // Setした内容をそのまま格納するため、検証しない
+            validateValue: false, // Setした内容をそのまま格納するため、検証しない
+            newModificationState: false // 要求は受理されたため、値を未変更状態にする
           );
+
+          // TODO: 受理されなかったプロパティについてはEchonetProperty.HasModified = trueに戻す
         }
 
         responseTCS.SetResult();
@@ -153,7 +156,8 @@ partial class EchonetClient
             esv: ESV.SetI,
             tid: transaction.ID,
             value: prop,
-            validateValue: false // Setした内容をそのまま格納するため、検証しない
+            validateValue: false, // Setした内容をそのまま格納するため、検証しない
+            newModificationState: true // 要求は受理されたと仮定するため、値は未変更状態とする
           );
         }
       }
@@ -235,8 +239,11 @@ partial class EchonetClient
             esv: value.Message.ESV,
             tid: value.TID,
             value: properties.First(p => p.EPC == prop.EPC),
-            validateValue: false // Setした内容をそのまま格納するため、検証しない
+            validateValue: false, // Setした内容をそのまま格納するため、検証しない
+            newModificationState: false // 要求は受理されたため、値を未変更状態にする
           );
+
+          // TODO: 受理されなかったプロパティについてはEchonetProperty.HasModified = trueに戻す
         }
 
         responseTCS.SetResult(
@@ -353,7 +360,8 @@ partial class EchonetClient
             esv: value.Message.ESV,
             tid: value.TID,
             value: prop,
-            validateValue: false // Getされた内容をそのまま格納するため、検証しない
+            validateValue: false, // Getされた内容をそのまま格納するため、検証しない
+            newModificationState: false // Getされた内容が格納されるため、値を未変更状態にする
           );
         }
 
@@ -480,8 +488,11 @@ partial class EchonetClient
             esv: value.Message.ESV,
             tid: value.TID,
             value: propertiesToSet.First(p => p.EPC == prop.EPC),
-            validateValue: false // Setした内容をそのまま格納するため、検証しない
+            validateValue: false, // Setした内容をそのまま格納するため、検証しない
+            newModificationState: false // 要求は受理されたため、値を未変更状態にする
           );
+
+          // TODO: 受理されなかったプロパティについてはEchonetProperty.HasModified = trueに戻す
         }
 
         // 要求が受理された読み出しを反映
@@ -490,7 +501,8 @@ partial class EchonetClient
             esv: value.Message.ESV,
             tid: value.TID,
             value: prop,
-            validateValue: false // Getされた内容をそのまま格納するため、検証しない
+            validateValue: false, // Getされた内容をそのまま格納するため、検証しない
+            newModificationState: false // Getされた内容が格納されるため、値を未変更状態にする
           );
         }
 

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
@@ -20,28 +20,20 @@ namespace Smdn.Net.EchonetLite;
 partial class EchonetClient
 #pragma warning restore IDE0040
 {
-  private static PropertyValue ConvertToPropertyValue(EchonetProperty p)
-    => new(epc: p.Code, edt: p.ValueMemory);
-
-  private static PropertyValue ConvertToPropertyValueExceptValueData(EchonetProperty p)
-    => new(epc: p.Code);
-
   /// <summary>
   /// ECHONET Lite サービス「SetI:プロパティ値書き込み要求（応答不要）」(ESV <c>0x60</c>)を行います。　このサービスは一斉同報が可能です。
   /// </summary>
-  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="destinationNode">相手先ECHONET Lite ノードを表す<see cref="EchonetNode"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
-  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="properties">処理対象のECHONET Lite プロパティとなる<see cref="IEnumerable{EchonetProperty}"/>。</param>
+  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="destinationNodeAddress">相手先ECHONET Lite ノードのアドレスを表す<see cref="IPAddress"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
+  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="properties">処理対象のECHONET Lite プロパティとなる<see cref="IEnumerable{PropertyValue}"/>。</param>
   /// <param name="cancellationToken">キャンセル要求を監視するためのトークン。 既定値は<see cref="CancellationToken.None"/>です。</param>
   /// <returns>
   /// 非同期の操作を表す<see cref="Task{T}"/>。
   /// 書き込みに成功したプロパティを<see cref="IReadOnlyCollection{PropertyValue}"/>で返します。
   /// </returns>
   /// <exception cref="ArgumentNullException">
-  /// <paramref name="sourceObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="properties"/>が<see langword="null"/>です。
+  /// <paramref name="properties"/>が<see langword="null"/>です。
   /// </exception>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
@@ -49,22 +41,18 @@ partial class EchonetClient
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.１ プロパティ値書き込みサービス（応答不要）［0x60, 0x50］
   /// </seealso>
-  public async Task<IReadOnlyCollection<PropertyValue>> PerformPropertyValueWriteRequestAsync(
-    EchonetObject sourceObject,
-    EchonetNode? destinationNode,
-    EchonetObject destinationObject,
-    IEnumerable<EchonetProperty> properties,
+  public async Task PerformPropertyValueWriteRequestAsync(
+    EOJ sourceObject,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
+    IEnumerable<PropertyValue> properties,
     CancellationToken cancellationToken = default
   )
   {
-    if (sourceObject is null)
-      throw new ArgumentNullException(nameof(sourceObject));
-    if (destinationObject is null)
-      throw new ArgumentNullException(nameof(destinationObject));
     if (properties is null)
       throw new ArgumentNullException(nameof(properties));
 
-    var responseTCS = new TaskCompletionSource<IReadOnlyCollection<PropertyValue>>();
+    var responseTCS = new TaskCompletionSource();
     using var transaction = StartNewTransaction();
 
     void HandleSetISNA(object? sender, (IPAddress Address, ushort TID, Format1Message Message) value)
@@ -75,30 +63,31 @@ partial class EchonetClient
           return;
         }
 
-        if (destinationNode is not null && !destinationNode.Address.Equals(value.Address))
+        if (destinationNodeAddress is not null && !destinationNodeAddress.Equals(value.Address))
           return;
         if (transaction.ID != value.TID)
           return;
-        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject.EOJ))
+        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject))
           return;
         if (value.Message.ESV != ESV.SetIServiceNotAvailable)
           return;
 
         logger?.LogDebug("Handling SetI_SNA (From: {Address}, TID: {TID:X4})", value.Address, value.TID);
 
+        // 不可応答ながらも要求が受理された書き込みを反映
+        var respondingObject = GetOrAddOtherNodeObject(value.Address, value.Message.SEOJ, value.Message.ESV);
         var props = value.Message.GetProperties();
 
-        // 一部成功した書き込みを反映
         foreach (var prop in props.Where(static p => p.PDC == 0)) {
-          _ = destinationObject.StorePropertyValue(
+          _ = respondingObject.StorePropertyValue(
             esv: value.Message.ESV,
             tid: value.TID,
-            value: ConvertToPropertyValue(properties.First(p => p.Code == prop.EPC)),
+            value: properties.First(p => p.EPC == prop.EPC),
             validateValue: false // Setした内容をそのまま格納するため、検証しない
           );
         }
 
-        responseTCS.SetResult(props);
+        responseTCS.SetResult();
 
         // TODO 一斉通知の不可応答の扱いが…
       }
@@ -110,14 +99,14 @@ partial class EchonetClient
     Format1MessageReceived += HandleSetISNA;
 
     await SendFrameAsync(
-      destinationNode?.Address,
+      destinationNodeAddress,
       buffer => FrameSerializer.SerializeEchonetLiteFrameFormat1(
         buffer: buffer,
         tid: transaction.ID,
-        sourceObject: sourceObject.EOJ,
-        destinationObject: destinationObject.EOJ,
+        sourceObject: sourceObject,
+        destinationObject: destinationObject,
         esv: ESV.SetI,
-        properties: properties.Select(ConvertToPropertyValue)
+        properties: properties
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -125,13 +114,20 @@ partial class EchonetClient
     try {
       using var ctr = cancellationToken.Register(() => _ = responseTCS.TrySetCanceled(cancellationToken));
 
-      return await responseTCS.Task.ConfigureAwait(false);
+      // FIXME: キャンセル要求があるか、いずれかから不可応答があるまで処理が返らない
+      await responseTCS.Task.ConfigureAwait(false);
     }
     catch (Exception ex) {
-      if (ex is OperationCanceledException exOperationCanceled && cancellationToken.Equals(exOperationCanceled.CancellationToken)) {
-        // 成功した書き込みを反映(全部OK)
-        foreach (var prop in properties.Select(ConvertToPropertyValue)) {
-          _ = destinationObject.StorePropertyValue(
+      if (
+        destinationNodeAddress is not null &&
+        ex is OperationCanceledException exOperationCanceled &&
+        cancellationToken.Equals(exOperationCanceled.CancellationToken)
+      ) {
+        // 個別送信の場合、要求がすべて受理されたと仮定して書き込みを反映
+        var destination = GetOrAddOtherNodeObject(destinationNodeAddress, destinationObject, ESV.SetI);
+
+        foreach (var prop in properties) {
+          _ = destination.StorePropertyValue(
             esv: ESV.SetI,
             tid: transaction.ID,
             value: prop,
@@ -149,10 +145,10 @@ partial class EchonetClient
   /// <summary>
   /// ECHONET Lite サービス「SetC:プロパティ値書き込み要求（応答要）」(ESV <c>0x61</c>)を行います。　このサービスは一斉同報が可能です。
   /// </summary>
-  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="destinationNode">相手先ECHONET Lite ノードを表す<see cref="EchonetNode"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
-  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="properties">処理対象のECHONET Lite プロパティとなる<see cref="IEnumerable{EchonetProperty}"/>。</param>
+  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="destinationNodeAddress">相手先ECHONET Lite ノードのアドレスを表す<see cref="IPAddress"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
+  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="properties">処理対象のECHONET Lite プロパティとなる<see cref="IEnumerable{PropertyValue}"/>。</param>
   /// <param name="cancellationToken">キャンセル要求を監視するためのトークン。 既定値は<see cref="CancellationToken.None"/>です。</param>
   /// <returns>
   /// 非同期の操作を表す<see cref="Task{T}"/>。
@@ -160,9 +156,7 @@ partial class EchonetClient
   /// また、書き込みに成功したプロパティを<see cref="IReadOnlyCollection{PropertyValue}"/>で返します。
   /// </returns>
   /// <exception cref="ArgumentNullException">
-  /// <paramref name="sourceObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="properties"/>が<see langword="null"/>です。
+  /// <paramref name="properties"/>が<see langword="null"/>です。
   /// </exception>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
@@ -170,26 +164,19 @@ partial class EchonetClient
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.２ プロパティ値書き込みサービス（応答要）［0x61,0x71,0x51］
   /// </seealso>
-  public async Task<(
-    bool Result,
-    IReadOnlyCollection<PropertyValue> Properties
-  )>
+  public async Task<bool>
   PerformPropertyValueWriteRequestResponseRequiredAsync(
-    EchonetObject sourceObject,
-    EchonetNode? destinationNode,
-    EchonetObject destinationObject,
-    IEnumerable<EchonetProperty> properties,
+    EOJ sourceObject,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
+    IEnumerable<PropertyValue> properties,
     CancellationToken cancellationToken = default
   )
   {
-    if (sourceObject is null)
-      throw new ArgumentNullException(nameof(sourceObject));
-    if (destinationObject is null)
-      throw new ArgumentNullException(nameof(destinationObject));
     if (properties is null)
       throw new ArgumentNullException(nameof(properties));
 
-    var responseTCS = new TaskCompletionSource<(bool, IReadOnlyCollection<PropertyValue>)>();
+    var responseTCS = new TaskCompletionSource<bool>();
     using var transaction = StartNewTransaction();
 
     void HandleSetResOrSetCSNA(object? sender_, (IPAddress Address, ushort TID, Format1Message Message) value)
@@ -200,11 +187,11 @@ partial class EchonetClient
           return;
         }
 
-        if (destinationNode is not null && !destinationNode.Address.Equals(value.Address))
+        if (destinationNodeAddress is not null && !destinationNodeAddress.Equals(value.Address))
           return;
         if (transaction.ID != value.TID)
           return;
-        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject.EOJ))
+        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject))
           return;
 
         if (value.Message.ESV == ESV.SetResponse)
@@ -214,19 +201,20 @@ partial class EchonetClient
         else
           return;
 
+        // 要求が受理された書き込みを反映
+        var respondingObject = GetOrAddOtherNodeObject(value.Address, value.Message.SEOJ, value.Message.ESV);
         var props = value.Message.GetProperties();
 
-        // 成功した書き込みを反映
         foreach (var prop in props.Where(static p => p.PDC == 0)) {
-          _ = destinationObject.StorePropertyValue(
+          _ = respondingObject.StorePropertyValue(
             esv: value.Message.ESV,
             tid: value.TID,
-            value: ConvertToPropertyValue(properties.First(p => p.Code == prop.EPC)),
+            value: properties.First(p => p.EPC == prop.EPC),
             validateValue: false // Setした内容をそのまま格納するため、検証しない
           );
         }
 
-        responseTCS.SetResult((value.Message.ESV == ESV.SetResponse, props));
+        responseTCS.SetResult(value.Message.ESV == ESV.SetResponse);
 
         // TODO 一斉通知の応答の扱いが…
       }
@@ -238,14 +226,14 @@ partial class EchonetClient
     Format1MessageReceived += HandleSetResOrSetCSNA;
 
     await SendFrameAsync(
-      destinationNode?.Address,
+      destinationNodeAddress,
       buffer => FrameSerializer.SerializeEchonetLiteFrameFormat1(
         buffer: buffer,
         tid: transaction.ID,
-        sourceObject: sourceObject.EOJ,
-        destinationObject: destinationObject.EOJ,
+        sourceObject: sourceObject,
+        destinationObject: destinationObject,
         esv: ESV.SetC,
-        properties: properties.Select(ConvertToPropertyValue)
+        properties: properties
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -253,6 +241,7 @@ partial class EchonetClient
     try {
       using var ctr = cancellationToken.Register(() => _ = responseTCS.TrySetCanceled(cancellationToken));
 
+      // TODO: 一斉送信の場合、停止要求があるまで待機させる
       return await responseTCS.Task.ConfigureAwait(false);
     }
     catch {
@@ -265,52 +254,9 @@ partial class EchonetClient
   /// <summary>
   /// ECHONET Lite サービス「Get:プロパティ値読み出し要求」(ESV <c>0x62</c>)を行います。　このサービスは一斉同報が可能です。
   /// </summary>
-  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="destinationNode">相手先ECHONET Lite ノードを表す<see cref="EchonetNode"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
-  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="properties">処理対象のECHONET Lite プロパティとなる<see cref="IEnumerable{EchonetProperty}"/>。</param>
-  /// <param name="cancellationToken">キャンセル要求を監視するためのトークン。 既定値は<see cref="CancellationToken.None"/>です。</param>
-  /// <returns>
-  /// 非同期の操作を表す<see cref="Task{T}"/>。
-  /// 成功応答(Get_Res <c>0x72</c>)の場合は<see langword="true"/>、不可応答(Get_SNA <c>0x52</c>)その他の場合は<see langword="false"/>を返します。
-  /// また、書き込みに成功したプロパティを<see cref="IReadOnlyCollection{PropertyValue}"/>で返します。
-  /// </returns>
-  /// <exception cref="ArgumentNullException">
-  /// <paramref name="sourceObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="properties"/>が<see langword="null"/>です。
-  /// </exception>
-  /// <seealso href="https://echonet.jp/spec_v114_lite/">
-  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
-  /// </seealso>
-  /// <seealso href="https://echonet.jp/spec_v114_lite/">
-  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.３ プロパティ値読み出しサービス［0x62,0x72,0x52］
-  /// </seealso>
-  public Task<(
-    bool Result,
-    IReadOnlyCollection<PropertyValue> Properties
-  )>
-  PerformPropertyValueReadRequestAsync(
-    EchonetObject sourceObject,
-    EchonetNode? destinationNode,
-    EchonetObject destinationObject,
-    IEnumerable<EchonetProperty> properties,
-    CancellationToken cancellationToken = default
-  )
-    => PerformPropertyValueReadRequestAsync(
-      sourceObject: sourceObject ?? throw new ArgumentNullException(nameof(sourceObject)),
-      destinationNode: destinationNode,
-      destinationObject: destinationObject ?? throw new ArgumentNullException(nameof(destinationObject)),
-      properties: (properties ?? throw new ArgumentNullException(nameof(properties))).Select(ConvertToPropertyValueExceptValueData),
-      cancellationToken: cancellationToken
-    );
-
-  /// <summary>
-  /// ECHONET Lite サービス「Get:プロパティ値読み出し要求」(ESV <c>0x62</c>)を行います。　このサービスは一斉同報が可能です。
-  /// </summary>
-  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="destinationNode">相手先ECHONET Lite ノードを表す<see cref="EchonetNode"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
-  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
+  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="destinationNodeAddress">相手先ECHONET Lite ノードのアドレスを表す<see cref="IPAddress"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
+  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
   /// <param name="propertyCodes">処理対象のECHONET Lite プロパティのプロパティコード(EPC)の一覧を表す<see cref="IEnumerable{Byte}"/>。</param>
   /// <param name="cancellationToken">キャンセル要求を監視するためのトークン。 既定値は<see cref="CancellationToken.None"/>です。</param>
   /// <returns>
@@ -319,9 +265,7 @@ partial class EchonetClient
   /// また、書き込みに成功したプロパティを<see cref="IReadOnlyCollection{PropertyValue}"/>で返します。
   /// </returns>
   /// <exception cref="ArgumentNullException">
-  /// <paramref name="sourceObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="propertyCodes"/>が<see langword="null"/>です。
+  /// <paramref name="propertyCodes"/>が<see langword="null"/>です。
   /// </exception>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
@@ -329,69 +273,19 @@ partial class EchonetClient
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.３ プロパティ値読み出しサービス［0x62,0x72,0x52］
   /// </seealso>
-  public Task<(
-    bool Result,
-    IReadOnlyCollection<PropertyValue> Properties
-  )>
+  public async Task<bool>
   PerformPropertyValueReadRequestAsync(
-    EchonetObject sourceObject,
-    EchonetNode? destinationNode,
-    EchonetObject destinationObject,
+    EOJ sourceObject,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
     IEnumerable<byte> propertyCodes,
     CancellationToken cancellationToken = default
   )
-    => PerformPropertyValueReadRequestAsync(
-      sourceObject: sourceObject ?? throw new ArgumentNullException(nameof(sourceObject)),
-      destinationNode: destinationNode,
-      destinationObject: destinationObject ?? throw new ArgumentNullException(nameof(destinationObject)),
-      properties: (propertyCodes ?? throw new ArgumentNullException(nameof(propertyCodes))).Select(PropertyValue.Create),
-      cancellationToken: cancellationToken
-    );
-
-  /// <summary>
-  /// ECHONET Lite サービス「Get:プロパティ値読み出し要求」(ESV <c>0x62</c>)を行います。　このサービスは一斉同報が可能です。
-  /// </summary>
-  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="destinationNode">相手先ECHONET Lite ノードを表す<see cref="EchonetNode"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
-  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="properties">処理対象のECHONET Lite プロパティの一覧を表す<see cref="IEnumerable{PropertyValue}"/>。</param>
-  /// <param name="cancellationToken">キャンセル要求を監視するためのトークン。 既定値は<see cref="CancellationToken.None"/>です。</param>
-  /// <returns>
-  /// 非同期の操作を表す<see cref="Task{T}"/>。
-  /// 成功応答(Get_Res <c>0x72</c>)の場合は<see langword="true"/>、不可応答(Get_SNA <c>0x52</c>)その他の場合は<see langword="false"/>を返します。
-  /// また、書き込みに成功したプロパティを<see cref="IReadOnlyCollection{PropertyValue}"/>で返します。
-  /// </returns>
-  /// <exception cref="ArgumentNullException">
-  /// <paramref name="sourceObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="properties"/>が<see langword="null"/>です。
-  /// </exception>
-  /// <seealso href="https://echonet.jp/spec_v114_lite/">
-  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
-  /// </seealso>
-  /// <seealso href="https://echonet.jp/spec_v114_lite/">
-  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.３ プロパティ値読み出しサービス［0x62,0x72,0x52］
-  /// </seealso>
-  private async Task<(
-    bool Result,
-    IReadOnlyCollection<PropertyValue> Properties
-  )>
-  PerformPropertyValueReadRequestAsync(
-    EchonetObject sourceObject,
-    EchonetNode? destinationNode,
-    EchonetObject destinationObject,
-    IEnumerable<PropertyValue> properties,
-    CancellationToken cancellationToken = default
-  )
   {
-    if (sourceObject is null)
-      throw new ArgumentNullException(nameof(sourceObject));
-    if (destinationObject is null)
-      throw new ArgumentNullException(nameof(destinationObject));
-    if (properties is null)
-      throw new ArgumentNullException(nameof(properties));
+    if (propertyCodes is null)
+      throw new ArgumentNullException(nameof(propertyCodes));
 
-    var responseTCS = new TaskCompletionSource<(bool, IReadOnlyCollection<PropertyValue>)>();
+    var responseTCS = new TaskCompletionSource<bool>();
     using var transaction = StartNewTransaction();
 
     void HandleGetResOrGetSNA(object? sender, (IPAddress Address, ushort TID, Format1Message Message) value)
@@ -402,11 +296,11 @@ partial class EchonetClient
           return;
         }
 
-        if (destinationNode is not null && !destinationNode.Address.Equals(value.Address))
+        if (destinationNodeAddress is not null && !destinationNodeAddress.Equals(value.Address))
           return;
         if (transaction.ID != value.TID)
           return;
-        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject.EOJ))
+        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject))
           return;
 
         if (value.Message.ESV == ESV.GetResponse)
@@ -416,11 +310,12 @@ partial class EchonetClient
         else
           return;
 
+        // 要求が受理された読み出しを反映
+        var respondingObject = GetOrAddOtherNodeObject(value.Address, value.Message.SEOJ, value.Message.ESV);
         var props = value.Message.GetProperties();
 
-        // 成功した読み込みを反映
         foreach (var prop in props.Where(static p => 0 < p.PDC)) {
-          _ = destinationObject.StorePropertyValue(
+          _ = respondingObject.StorePropertyValue(
             esv: value.Message.ESV,
             tid: value.TID,
             value: prop,
@@ -428,7 +323,7 @@ partial class EchonetClient
           );
         }
 
-        responseTCS.SetResult((value.Message.ESV == ESV.GetResponse, props));
+        responseTCS.SetResult(value.Message.ESV == ESV.GetResponse);
 
         // TODO 一斉通知の応答の扱いが…
       }
@@ -440,14 +335,14 @@ partial class EchonetClient
     Format1MessageReceived += HandleGetResOrGetSNA;
 
     await SendFrameAsync(
-      destinationNode?.Address,
+      destinationNodeAddress,
       buffer => FrameSerializer.SerializeEchonetLiteFrameFormat1(
         buffer: buffer,
         tid: transaction.ID,
-        sourceObject: sourceObject.EOJ,
-        destinationObject: destinationObject.EOJ,
+        sourceObject: sourceObject,
+        destinationObject: destinationObject,
         esv: ESV.Get,
-        properties: properties
+        properties: propertyCodes.Select(PropertyValue.Create)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -455,6 +350,7 @@ partial class EchonetClient
     try {
       using var ctr = cancellationToken.Register(() => _ = responseTCS.TrySetCanceled(cancellationToken));
 
+      // TODO: 一斉送信の場合、停止要求があるまで待機させる
       return await responseTCS.Task.ConfigureAwait(false);
     }
     catch {
@@ -467,11 +363,11 @@ partial class EchonetClient
   /// <summary>
   /// ECHONET Lite サービス「SetGet:プロパティ値書き込み・読み出し要求」(ESV <c>0x6E</c>)を行います。　このサービスは一斉同報が可能です。
   /// </summary>
-  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="destinationNode">相手先ECHONET Lite ノードを表す<see cref="EchonetNode"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
-  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="propertiesSet">書き込み対象のECHONET Lite プロパティとなる<see cref="IEnumerable{EchonetProperty}"/>。</param>
-  /// <param name="propertiesGet">読み出し対象のECHONET Lite プロパティとなる<see cref="IEnumerable{EchonetProperty}"/>。</param>
+  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="destinationNodeAddress">相手先ECHONET Lite ノードのアドレスを表す<see cref="IPAddress"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
+  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="propertiesToSet">書き込み対象のECHONET Lite プロパティとなる<see cref="IEnumerable{PropertyValue}"/>。</param>
+  /// <param name="propertyCodesToGet">読み出し対象のECHONET Lite プロパティのプロパティコード(EPC)の一覧を表す<see cref="IEnumerable{Byte}"/>。</param>
   /// <param name="cancellationToken">キャンセル要求を監視するためのトークン。 既定値は<see cref="CancellationToken.None"/>です。</param>
   /// <returns>
   /// 非同期の操作を表す<see cref="Task{T}"/>。
@@ -479,10 +375,8 @@ partial class EchonetClient
   /// また、処理に成功したプロパティを書き込み対象プロパティ・読み出し対象プロパティの順にて<see cref="IReadOnlyCollection{PropertyValue}"/>で返します。
   /// </returns>
   /// <exception cref="ArgumentNullException">
-  /// <paramref name="sourceObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="propertiesSet"/>が<see langword="null"/>です。
-  /// または、<paramref name="propertiesGet"/>が<see langword="null"/>です。
+  /// <paramref name="propertiesToSet"/>が<see langword="null"/>です。
+  /// または、<paramref name="propertyCodesToGet"/>が<see langword="null"/>です。
   /// </exception>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
@@ -490,30 +384,22 @@ partial class EchonetClient
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.４ プロパティ値書き込み読み出しサービス［0x6E,0x7E,0x5E］
   /// </seealso>
-  public async Task<(
-    bool Result,
-    IReadOnlyCollection<PropertyValue> PropertiesSet,
-    IReadOnlyCollection<PropertyValue> PropertiesGet
-  )>
+  public async Task<bool>
   PerformPropertyValueWriteReadRequestAsync(
-    EchonetObject sourceObject,
-    EchonetNode? destinationNode,
-    EchonetObject destinationObject,
-    IEnumerable<EchonetProperty> propertiesSet,
-    IEnumerable<EchonetProperty> propertiesGet,
+    EOJ sourceObject,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
+    IEnumerable<PropertyValue> propertiesToSet,
+    IEnumerable<byte> propertyCodesToGet,
     CancellationToken cancellationToken = default
   )
   {
-    if (sourceObject is null)
-      throw new ArgumentNullException(nameof(sourceObject));
-    if (destinationObject is null)
-      throw new ArgumentNullException(nameof(destinationObject));
-    if (propertiesSet is null)
-      throw new ArgumentNullException(nameof(propertiesSet));
-    if (propertiesGet is null)
-      throw new ArgumentNullException(nameof(propertiesGet));
+    if (propertiesToSet is null)
+      throw new ArgumentNullException(nameof(propertiesToSet));
+    if (propertyCodesToGet is null)
+      throw new ArgumentNullException(nameof(propertyCodesToGet));
 
-    var responseTCS = new TaskCompletionSource<(bool, IReadOnlyCollection<PropertyValue>, IReadOnlyCollection<PropertyValue>)>();
+    var responseTCS = new TaskCompletionSource<bool>();
     using var transaction = StartNewTransaction();
 
     void HandleSetGetResOrSetGetSNA(object? sender_, (IPAddress Address, ushort TID, Format1Message Message) value)
@@ -524,11 +410,11 @@ partial class EchonetClient
           return;
         }
 
-        if (destinationNode is not null && !destinationNode.Address.Equals(value.Address))
+        if (destinationNodeAddress is not null && !destinationNodeAddress.Equals(value.Address))
           return;
         if (transaction.ID != value.TID)
           return;
-        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject.EOJ))
+        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject))
           return;
 
         if (value.Message.ESV == ESV.SetGetResponse)
@@ -538,21 +424,22 @@ partial class EchonetClient
         else
           return;
 
+        var respondingObject = GetOrAddOtherNodeObject(value.Address, value.Message.SEOJ, value.Message.ESV);
         var (propsForSet, propsForGet) = value.Message.GetPropertiesForSetAndGet();
 
-        // 成功した書き込みを反映
+        // 要求が受理された書き込みを反映
         foreach (var prop in propsForSet.Where(static p => p.PDC == 0)) {
-          _ = destinationObject.StorePropertyValue(
+          _ = respondingObject.StorePropertyValue(
             esv: value.Message.ESV,
             tid: value.TID,
-            value: ConvertToPropertyValue(propertiesSet.First(p => p.Code == prop.EPC)),
+            value: propertiesToSet.First(p => p.EPC == prop.EPC),
             validateValue: false // Setした内容をそのまま格納するため、検証しない
           );
         }
 
-        // 成功した読み込みを反映
+        // 要求が受理された読み出しを反映
         foreach (var prop in propsForGet.Where(static p => 0 < p.PDC)) {
-          _ = destinationObject.StorePropertyValue(
+          _ = respondingObject.StorePropertyValue(
             esv: value.Message.ESV,
             tid: value.TID,
             value: prop,
@@ -560,7 +447,7 @@ partial class EchonetClient
           );
         }
 
-        responseTCS.SetResult((value.Message.ESV == ESV.SetGetResponse, propsForSet, propsForGet));
+        responseTCS.SetResult(value.Message.ESV == ESV.SetGetResponse);
 
         // TODO 一斉通知の応答の扱いが…
       }
@@ -572,15 +459,15 @@ partial class EchonetClient
     Format1MessageReceived += HandleSetGetResOrSetGetSNA;
 
     await SendFrameAsync(
-      destinationNode?.Address,
+      destinationNodeAddress,
       buffer => FrameSerializer.SerializeEchonetLiteFrameFormat1(
         buffer: buffer,
         tid: transaction.ID,
-        sourceObject: sourceObject.EOJ,
-        destinationObject: destinationObject.EOJ,
+        sourceObject: sourceObject,
+        destinationObject: destinationObject,
         esv: ESV.SetGet,
-        propertiesForSet: propertiesSet.Select(ConvertToPropertyValue),
-        propertiesForGet: propertiesGet.Select(ConvertToPropertyValueExceptValueData)
+        propertiesForSet: propertiesToSet,
+        propertiesForGet: propertyCodesToGet.Select(PropertyValue.Create)
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -588,6 +475,7 @@ partial class EchonetClient
     try {
       using var ctr = cancellationToken.Register(() => _ = responseTCS.TrySetCanceled(cancellationToken));
 
+      // TODO: 一斉送信の場合、停止要求があるまで待機させる
       return await responseTCS.Task.ConfigureAwait(false);
     }
     catch {
@@ -600,55 +488,16 @@ partial class EchonetClient
   /// <summary>
   /// ECHONET Lite サービス「INF_REQ:プロパティ値通知要求」(ESV <c>0x63</c>)を行います。　このサービスは一斉同報が可能です。
   /// </summary>
-  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="destinationNode">相手先ECHONET Lite ノードを表す<see cref="EchonetNode"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
-  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="properties">処理対象のECHONET Lite プロパティの一覧を表す<see cref="IEnumerable{EchonetProperty}"/>。</param>
-  /// <param name="cancellationToken">キャンセル要求を監視するためのトークン。 既定値は<see cref="CancellationToken.None"/>です。</param>
-  /// <returns>
-  /// 非同期の操作を表す<see cref="ValueTask"/>。
-  /// </returns>
-  /// <exception cref="ArgumentNullException">
-  /// <paramref name="sourceObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="properties"/>が<see langword="null"/>です。
-  /// </exception>
-  /// <seealso href="https://echonet.jp/spec_v114_lite/">
-  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
-  /// </seealso>
-  /// <seealso href="https://echonet.jp/spec_v114_lite/">
-  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
-  /// </seealso>
-  public ValueTask PerformPropertyValueNotificationRequestAsync(
-    EchonetObject sourceObject,
-    EchonetNode? destinationNode,
-    EchonetObject destinationObject,
-    IEnumerable<EchonetProperty> properties,
-    CancellationToken cancellationToken = default
-  )
-    => PerformPropertyValueNotificationRequestAsync(
-      sourceObject: sourceObject ?? throw new ArgumentNullException(nameof(sourceObject)),
-      destinationNode: destinationNode,
-      destinationObject: destinationObject ?? throw new ArgumentNullException(nameof(destinationObject)),
-      properties: (properties ?? throw new ArgumentNullException(nameof(properties))).Select(ConvertToPropertyValueExceptValueData),
-      cancellationToken: cancellationToken
-    );
-
-  /// <summary>
-  /// ECHONET Lite サービス「INF_REQ:プロパティ値通知要求」(ESV <c>0x63</c>)を行います。　このサービスは一斉同報が可能です。
-  /// </summary>
-  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="destinationNode">相手先ECHONET Lite ノードを表す<see cref="EchonetNode"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
-  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
+  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="destinationNodeAddress">相手先ECHONET Lite ノードのアドレスを表す<see cref="IPAddress"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
+  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
   /// <param name="propertyCodes">処理対象のECHONET Lite プロパティのプロパティコード(EPC)の一覧を表す<see cref="IEnumerable{Byte}"/>。</param>
   /// <param name="cancellationToken">キャンセル要求を監視するためのトークン。 既定値は<see cref="CancellationToken.None"/>です。</param>
   /// <returns>
   /// 非同期の操作を表す<see cref="ValueTask"/>。
   /// </returns>
   /// <exception cref="ArgumentNullException">
-  /// <paramref name="sourceObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="propertyCodes"/>が<see langword="null"/>です。
+  /// <paramref name="propertyCodes"/>が<see langword="null"/>です。
   /// </exception>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
@@ -657,70 +506,29 @@ partial class EchonetClient
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
   /// </seealso>
   public ValueTask PerformPropertyValueNotificationRequestAsync(
-    EchonetObject sourceObject,
-    EchonetNode? destinationNode,
-    EchonetObject destinationObject,
+    EOJ sourceObject,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
     IEnumerable<byte> propertyCodes,
     CancellationToken cancellationToken = default
   )
-    => PerformPropertyValueNotificationRequestAsync(
-      sourceObject: sourceObject ?? throw new ArgumentNullException(nameof(sourceObject)),
-      destinationNode: destinationNode,
-      destinationObject: destinationObject ?? throw new ArgumentNullException(nameof(destinationObject)),
-      properties: (propertyCodes ?? throw new ArgumentNullException(nameof(propertyCodes))).Select(PropertyValue.Create),
-      cancellationToken: cancellationToken
-    );
-
-  /// <summary>
-  /// ECHONET Lite サービス「INF_REQ:プロパティ値通知要求」(ESV <c>0x63</c>)を行います。　このサービスは一斉同報が可能です。
-  /// </summary>
-  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="destinationNode">相手先ECHONET Lite ノードを表す<see cref="EchonetNode"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
-  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="properties">処理対象のECHONET Lite プロパティの一覧を表す<see cref="IEnumerable{PropertyValue}"/>。</param>
-  /// <param name="cancellationToken">キャンセル要求を監視するためのトークン。 既定値は<see cref="CancellationToken.None"/>です。</param>
-  /// <returns>
-  /// 非同期の操作を表す<see cref="ValueTask"/>。
-  /// </returns>
-  /// <exception cref="ArgumentNullException">
-  /// <paramref name="sourceObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="properties"/>が<see langword="null"/>です。
-  /// </exception>
-  /// <seealso href="https://echonet.jp/spec_v114_lite/">
-  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
-  /// </seealso>
-  /// <seealso href="https://echonet.jp/spec_v114_lite/">
-  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
-  /// </seealso>
-  private ValueTask PerformPropertyValueNotificationRequestAsync(
-    EchonetObject sourceObject,
-    EchonetNode? destinationNode,
-    EchonetObject destinationObject,
-    IEnumerable<PropertyValue> properties,
-    CancellationToken cancellationToken = default
-  )
   {
-    if (sourceObject is null)
-      throw new ArgumentNullException(nameof(sourceObject));
-    if (destinationObject is null)
-      throw new ArgumentNullException(nameof(destinationObject));
-    if (properties is null)
-      throw new ArgumentNullException(nameof(properties));
+    if (propertyCodes is null)
+      throw new ArgumentNullException(nameof(propertyCodes));
 
     // 要求の送信を行ったあとは、応答を待機せずにトランザクションを終了する
     // 応答の処理は共通のハンドラで行う
     using var transaction = StartNewTransaction();
 
     return SendFrameAsync(
-      destinationNode?.Address,
+      destinationNodeAddress,
       buffer => FrameSerializer.SerializeEchonetLiteFrameFormat1(
         buffer: buffer,
         tid: transaction.ID,
-        sourceObject: sourceObject.EOJ,
-        destinationObject: destinationObject.EOJ,
+        sourceObject: sourceObject,
+        destinationObject: destinationObject,
         esv: ESV.InfRequest,
-        properties: properties
+        properties: propertyCodes.Select(PropertyValue.Create)
       ),
       cancellationToken
     );
@@ -729,18 +537,16 @@ partial class EchonetClient
   /// <summary>
   /// ECHONET Lite サービス「INF:プロパティ値通知」(ESV <c>0x73</c>)を行います。　このサービスは個別通知・一斉同報通知ともに可能です。
   /// </summary>
-  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="destinationNode">相手先ECHONET Lite ノードを表す<see cref="EchonetNode"/>。 <see langword="null"/>の場合、一斉同報通知を行います。</param>
-  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="properties">処理対象のECHONET Lite プロパティとなる<see cref="IEnumerable{EchonetProperty}"/>。</param>
+  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="properties">処理対象のECHONET Lite プロパティとなる<see cref="IEnumerable{PropertyValue}"/>。</param>
+  /// <param name="destinationNodeAddress">相手先ECHONET Lite ノードのアドレスを表す<see cref="IPAddress"/>。</param>
+  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
   /// <param name="cancellationToken">キャンセル要求を監視するためのトークン。 既定値は<see cref="CancellationToken.None"/>です。</param>
   /// <returns>
   /// 非同期の操作を表す<see cref="ValueTask"/>。
   /// </returns>
   /// <exception cref="ArgumentNullException">
-  /// <paramref name="sourceObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="properties"/>が<see langword="null"/>です。
+  /// <paramref name="properties"/>が<see langword="null"/>です。
   /// </exception>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
@@ -749,17 +555,13 @@ partial class EchonetClient
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
   /// </seealso>
   public ValueTask PerformPropertyValueNotificationAsync(
-    EchonetObject sourceObject,
-    EchonetNode? destinationNode,
-    EchonetObject destinationObject,
-    IEnumerable<EchonetProperty> properties,
+    EOJ sourceObject,
+    IEnumerable<PropertyValue> properties,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
     CancellationToken cancellationToken = default
   )
   {
-    if (sourceObject is null)
-      throw new ArgumentNullException(nameof(sourceObject));
-    if (destinationObject is null)
-      throw new ArgumentNullException(nameof(destinationObject));
     if (properties is null)
       throw new ArgumentNullException(nameof(properties));
 
@@ -768,14 +570,14 @@ partial class EchonetClient
     using var transaction = StartNewTransaction();
 
     return SendFrameAsync(
-      destinationNode?.Address,
+      destinationNodeAddress,
       buffer => FrameSerializer.SerializeEchonetLiteFrameFormat1(
         buffer: buffer,
         tid: transaction.ID,
-        sourceObject: sourceObject.EOJ,
-        destinationObject: destinationObject.EOJ,
+        sourceObject: sourceObject,
+        destinationObject: destinationObject,
         esv: ESV.Inf,
-        properties: properties.Select(ConvertToPropertyValue)
+        properties: properties
       ),
       cancellationToken
     );
@@ -784,20 +586,18 @@ partial class EchonetClient
   /// <summary>
   /// ECHONET Lite サービス「INFC:プロパティ値通知（応答要）」(ESV <c>0x74</c>)を行います。　このサービスは個別通知のみ可能です。
   /// </summary>
-  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="destinationNode">相手先ECHONET Lite ノードを表す<see cref="EchonetNode"/>。</param>
-  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EchonetObject"/>。</param>
-  /// <param name="properties">処理対象のECHONET Lite プロパティとなる<see cref="IEnumerable{EchonetProperty}"/>。</param>
+  /// <param name="sourceObject">送信元ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
+  /// <param name="properties">処理対象のECHONET Lite プロパティとなる<see cref="IEnumerable{PropertyValue}"/>。</param>
+  /// <param name="destinationNodeAddress">相手先ECHONET Lite ノードのアドレスを表す<see cref="IPAddress"/>。</param>
+  /// <param name="destinationObject">相手先ECHONET Lite オブジェクトを表す<see cref="EOJ"/>。</param>
   /// <param name="cancellationToken">キャンセル要求を監視するためのトークン。 既定値は<see cref="CancellationToken.None"/>です。</param>
   /// <returns>
   /// 非同期の操作を表す<see cref="Task{T}"/>。
   /// 通知に成功したプロパティを<see cref="IReadOnlyCollection{PropertyValue}"/>で返します。
   /// </returns>
   /// <exception cref="ArgumentNullException">
-  /// <paramref name="sourceObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationNode"/>が<see langword="null"/>です。
-  /// または、<paramref name="destinationObject"/>が<see langword="null"/>です。
-  /// または、<paramref name="properties"/>が<see langword="null"/>です。
+  /// <paramref name="properties"/>が<see langword="null"/>です。
+  /// または、<paramref name="destinationNodeAddress"/>が<see langword="null"/>です。
   /// </exception>
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
@@ -805,24 +605,21 @@ partial class EchonetClient
   /// <seealso href="https://echonet.jp/spec_v114_lite/">
   /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.６ プロパティ値通知(応答要)サービス［0x74, 0x7A］
   /// </seealso>
-  public async Task<IReadOnlyCollection<PropertyValue>> PerformPropertyValueNotificationResponseRequiredAsync(
-    EchonetObject sourceObject,
-    EchonetNode destinationNode,
-    EchonetObject destinationObject,
-    IEnumerable<EchonetProperty> properties,
+  public async Task
+  PerformPropertyValueNotificationResponseRequiredAsync(
+    EOJ sourceObject,
+    IEnumerable<PropertyValue> properties,
+    IPAddress destinationNodeAddress,
+    EOJ destinationObject,
     CancellationToken cancellationToken = default
   )
   {
-    if (sourceObject is null)
-      throw new ArgumentNullException(nameof(sourceObject));
-    if (destinationNode is null)
-      throw new ArgumentNullException(nameof(destinationNode));
-    if (destinationObject is null)
-      throw new ArgumentNullException(nameof(destinationObject));
+    if (destinationNodeAddress is null)
+      throw new ArgumentNullException(nameof(destinationNodeAddress));
     if (properties is null)
       throw new ArgumentNullException(nameof(properties));
 
-    var responseTCS = new TaskCompletionSource<IReadOnlyCollection<PropertyValue>>();
+    var responseTCS = new TaskCompletionSource();
     using var transaction = StartNewTransaction();
 
     void HandleINFCRes(object? sender, (IPAddress Address, ushort TID, Format1Message Message) value)
@@ -833,18 +630,18 @@ partial class EchonetClient
           return;
         }
 
-        if (!destinationNode.Address.Equals(value.Address))
+        if (!destinationNodeAddress.Equals(value.Address))
           return;
         if (transaction.ID != value.TID)
           return;
-        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject.EOJ))
+        if (!EOJ.AreSame(value.Message.SEOJ, destinationObject))
           return;
         if (value.Message.ESV != ESV.InfCResponse)
           return;
 
         logger?.LogDebug("Handling INFC_Res (From: {Address}, TID: {TID:X4})", value.Address, value.TID);
 
-        responseTCS.SetResult(value.Message.GetProperties());
+        responseTCS.SetResult();
       }
       finally {
         Format1MessageReceived -= HandleINFCRes;
@@ -854,14 +651,14 @@ partial class EchonetClient
     Format1MessageReceived += HandleINFCRes;
 
     await SendFrameAsync(
-      destinationNode.Address,
+      destinationNodeAddress,
       buffer => FrameSerializer.SerializeEchonetLiteFrameFormat1(
         buffer: buffer,
         tid: transaction.ID,
-        sourceObject: sourceObject.EOJ,
-        destinationObject: destinationObject.EOJ,
+        sourceObject: sourceObject,
+        destinationObject: destinationObject,
         esv: ESV.InfC,
-        properties: properties.Select(ConvertToPropertyValue)
+        properties: properties
       ),
       cancellationToken
     ).ConfigureAwait(false);
@@ -869,7 +666,7 @@ partial class EchonetClient
     try {
       using var ctr = cancellationToken.Register(() => _ = responseTCS.TrySetCanceled(cancellationToken));
 
-      return await responseTCS.Task.ConfigureAwait(false);
+      await responseTCS.Task.ConfigureAwait(false);
     }
     catch {
       Format1MessageReceived -= HandleINFCRes;

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
@@ -251,5 +251,17 @@ public partial class EchonetClient : IEchonetClientService, IDisposable, IAsyncD
     return otherNode;
   }
 
+  /// <summary>
+  /// 他ノードに属するECHONET オブジェクトを表す<see cref="EchonetObject"/>を取得または作成します。
+  /// </summary>
+  /// <param name="address">他ノードのアドレス。</param>
+  /// <param name="obj">他ノードのECHONET オブジェクトの<see cref="EOJ"/>。</param>
+  /// <param name="esv">この要求を行う契機となったECHONETサービスを表す<see cref="ESV"/> 。</param>
+  /// <returns>
+  /// 該当するECHONET オブジェクトを表すsee cref="EchonetObject"/>。
+  /// </returns>
+  private EchonetObject GetOrAddOtherNodeObject(IPAddress address, EOJ obj, ESV esv)
+    => GetOrAddOtherNode(address, esv).GetOrAddDevice(deviceFactory, obj, out _);
+
   IPAddress? IEchonetClientService.GetSelfNodeAddress() => GetSelfNodeAddress();
 }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2018 HiroyukiSakoh
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
+#pragma warning disable CA1506 // CA1506: Rewrite or refactor the code to decrease its class coupling below '96'.
 #pragma warning disable CA1848 // CA1848: パフォーマンスを向上させるには、LoggerMessage デリゲートを使用します -->
 
 using System;

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetDevice.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetDevice.cs
@@ -113,7 +113,8 @@ public class EchonetDevice : EchonetObject {
     ESV esv,
     ushort tid,
     PropertyValue value,
-    bool validateValue
+    bool validateValue,
+    bool? newModificationState
   )
   {
     if (!properties.TryGetValue(value.EPC, out var property)) {
@@ -142,7 +143,7 @@ public class EchonetDevice : EchonetObject {
     if (validateValue && !property.IsAcceptableValue(value.EDT.Span))
       return false;
 
-    property.SetValue(esv, tid, value);
+    property.SetValue(esv, tid, value, newModificationState);
 
     return true;
   }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
@@ -156,6 +156,10 @@ public abstract partial class EchonetObject {
   /// <param name="validateValue">
   /// 格納される値が、詳細仕様での規定に即しているか検証するかどうかを指定する<see cref="bool"/>値。
   /// </param>
+  /// <param name="newModificationState">
+  /// 格納対象のプロパティの<see cref="EchonetProperty.HasModified"/>を設定する場合は<see langword="true"/>または<see langword="false"/>、
+  /// そのままにする場合は<see langword="null"/>。
+  /// </param>
   /// <returns>
   /// 格納対象となるECHONET プロパティ(EPC)が詳細仕様として規定されていない場合、
   /// または<paramref name="validateValue"/>の指定による検証の結果、詳細仕様での規定に即していない値の場合は<see langword="false"/>。
@@ -165,7 +169,8 @@ public abstract partial class EchonetObject {
     ESV esv,
     ushort tid,
     PropertyValue value,
-    bool validateValue
+    bool validateValue,
+    bool? newModificationState
   );
 
   public override string ToString()

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObjectExtensions.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObjectExtensions.cs
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Smdn.Net.EchonetLite.Protocol;
+
+namespace Smdn.Net.EchonetLite;
+
+public static class EchonetObjectExtensions {
+  private static IEchonetClientService GetClientServiceOrThrow(EchonetObject obj)
+    => obj.OwnerNode?.Owner ?? throw new InvalidOperationException("could not get client");
+
+  private static InvalidOperationException CreateCanNotSpecifySelfNodeAsDestination()
+    => new("Can not specify the self node as the destination.");
+
+  private static InvalidOperationException CreateCanNotSpecifyOtherNodeAsSource()
+    => new("Can not specify the other node as the source.");
+
+  private static IEnumerable<PropertyValue> EnumeratePropertyValues(EchonetObject obj, IEnumerable<byte> propertyCodes)
+  {
+    foreach (var code in propertyCodes) {
+      if (obj.Properties.TryGetValue(code, out var prop))
+        yield return new(prop.Code, prop.ValueMemory);
+    }
+  }
+
+  /// <summary>
+  /// ECHONET Lite サービス「SetI:プロパティ値書き込み要求（応答不要）」(ESV <c>0x60</c>)を行います。　このサービスは一斉同報が可能です。
+  /// </summary>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
+  /// </seealso>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.１ プロパティ値書き込みサービス（応答不要）［0x60, 0x50］
+  /// </seealso>
+  public static async ValueTask WritePropertiesOneWayAsync(
+    this EchonetObject destinationObject,
+    IEnumerable<byte> writePropertyCodes,
+    EchonetObject sourceObject,
+    CancellationToken cancellationToken = default
+  )
+  {
+    if (destinationObject is null)
+      throw new ArgumentNullException(nameof(destinationObject));
+    if (destinationObject.Node is EchonetSelfNode)
+      throw CreateCanNotSpecifySelfNodeAsDestination();
+    if (writePropertyCodes is null)
+      throw new ArgumentNullException(nameof(writePropertyCodes));
+    if (sourceObject is null)
+      throw new ArgumentNullException(nameof(sourceObject));
+
+    await GetClientServiceOrThrow(destinationObject).RequestWriteOneWayAsync(
+      sourceObject: sourceObject.EOJ,
+      destinationNodeAddress: destinationObject.Node.Address,
+      destinationObject: destinationObject.EOJ,
+      properties: EnumeratePropertyValues(destinationObject, writePropertyCodes),
+      cancellationToken: cancellationToken
+    ).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  /// ECHONET Lite サービス「SetC:プロパティ値書き込み要求（応答要）」(ESV <c>0x61</c>)を行います。　このサービスは一斉同報が可能です。
+  /// </summary>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
+  /// </seealso>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.２ プロパティ値書き込みサービス（応答要）［0x61,0x71,0x51］
+  /// </seealso>
+  public static async ValueTask<EchonetServiceResponse> WritePropertiesAsync(
+    this EchonetObject destinationObject,
+    IEnumerable<byte> writePropertyCodes,
+    EchonetObject sourceObject,
+    CancellationToken cancellationToken = default
+  )
+  {
+    if (destinationObject is null)
+      throw new ArgumentNullException(nameof(destinationObject));
+    if (destinationObject.Node is EchonetSelfNode)
+      throw CreateCanNotSpecifySelfNodeAsDestination();
+    if (writePropertyCodes is null)
+      throw new ArgumentNullException(nameof(writePropertyCodes));
+    if (sourceObject is null)
+      throw new ArgumentNullException(nameof(sourceObject));
+
+    return await GetClientServiceOrThrow(destinationObject).RequestWriteAsync(
+      sourceObject: sourceObject.EOJ,
+      destinationNodeAddress: destinationObject.Node.Address,
+      destinationObject: destinationObject.EOJ,
+      properties: EnumeratePropertyValues(destinationObject, writePropertyCodes),
+      cancellationToken: cancellationToken
+    ).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  /// ECHONET Lite サービス「Get:プロパティ値読み出し要求」(ESV <c>0x62</c>)を行います。　このサービスは一斉同報が可能です。
+  /// </summary>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
+  /// </seealso>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.３ プロパティ値読み出しサービス［0x62,0x72,0x52］
+  /// </seealso>
+  public static async ValueTask<EchonetServiceResponse>
+  ReadPropertiesAsync(
+    this EchonetObject destinationObject,
+    IEnumerable<byte> readPropertyCodes,
+    EchonetObject sourceObject,
+    CancellationToken cancellationToken = default
+  )
+  {
+    if (destinationObject is null)
+      throw new ArgumentNullException(nameof(destinationObject));
+    if (destinationObject.Node is EchonetSelfNode)
+      throw CreateCanNotSpecifySelfNodeAsDestination();
+    if (readPropertyCodes is null)
+      throw new ArgumentNullException(nameof(readPropertyCodes));
+    if (sourceObject is null)
+      throw new ArgumentNullException(nameof(sourceObject));
+
+    return await GetClientServiceOrThrow(destinationObject).RequestReadAsync(
+      sourceObject: sourceObject.EOJ,
+      destinationNodeAddress: destinationObject.Node.Address,
+      destinationObject: destinationObject.EOJ,
+      propertyCodes: readPropertyCodes,
+      cancellationToken: cancellationToken
+    ).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  /// ECHONET Lite サービス「SetGet:プロパティ値書き込み・読み出し要求」(ESV <c>0x6E</c>)を行います。　このサービスは一斉同報が可能です。
+  /// </summary>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
+  /// </seealso>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.４ プロパティ値書き込み読み出しサービス［0x6E,0x7E,0x5E］
+  /// </seealso>
+  public static async ValueTask<(EchonetServiceResponse SetResponse, EchonetServiceResponse GetResponse)>
+  WriteReadPropertiesAsync(
+    this EchonetObject destinationObject,
+    IEnumerable<byte> writePropertyCodes,
+    IEnumerable<byte> readPropertyCodes,
+    EchonetObject sourceObject,
+    CancellationToken cancellationToken = default
+  )
+  {
+    if (destinationObject is null)
+      throw new ArgumentNullException(nameof(destinationObject));
+    if (destinationObject.Node is EchonetSelfNode)
+      throw CreateCanNotSpecifySelfNodeAsDestination();
+    if (writePropertyCodes is null)
+      throw new ArgumentNullException(nameof(writePropertyCodes));
+    if (readPropertyCodes is null)
+      throw new ArgumentNullException(nameof(readPropertyCodes));
+    if (sourceObject is null)
+      throw new ArgumentNullException(nameof(sourceObject));
+
+    return await GetClientServiceOrThrow(destinationObject).RequestWriteReadAsync(
+      sourceObject: sourceObject.EOJ,
+      destinationNodeAddress: destinationObject.Node.Address,
+      destinationObject: destinationObject.EOJ,
+      propertiesToSet: EnumeratePropertyValues(destinationObject, writePropertyCodes),
+      propertyCodesToGet: readPropertyCodes,
+      cancellationToken: cancellationToken
+    ).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  /// ECHONET Lite サービス「INF_REQ:プロパティ値通知要求」(ESV <c>0x63</c>)を行います。　このサービスは一斉同報が可能です。
+  /// </summary>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
+  /// </seealso>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
+  /// </seealso>
+  public static ValueTask RequestNotifyPropertiesOneWayMulticastAsync(
+    this EchonetObject sourceObject,
+    EOJ destinationObject,
+    IEnumerable<byte> requestNotifyPropertyCodes,
+    CancellationToken cancellationToken = default
+  )
+  {
+    if (sourceObject is null)
+      throw new ArgumentNullException(nameof(sourceObject));
+    if (sourceObject.Node is not EchonetSelfNode)
+      throw CreateCanNotSpecifyOtherNodeAsSource();
+    if (requestNotifyPropertyCodes is null)
+      throw new ArgumentNullException(nameof(requestNotifyPropertyCodes));
+
+    return GetClientServiceOrThrow(sourceObject).RequestNotifyOneWayAsync(
+      sourceObject: sourceObject.EOJ,
+      propertyCodes: requestNotifyPropertyCodes,
+      destinationNodeAddress: null, // multicast
+      destinationObject: destinationObject,
+      cancellationToken: cancellationToken
+    );
+  }
+
+  /// <summary>
+  /// ECHONET Lite サービス「INF:プロパティ値通知」(ESV <c>0x73</c>)を行います。　このサービスは個別通知・一斉同報通知ともに可能です。
+  /// </summary>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ３．２．５ ECHONET Lite サービス（ESV）
+  /// </seealso>
+  /// <seealso href="https://echonet.jp/spec_v114_lite/">
+  /// ECHONET Lite規格書 Ver.1.14 第2部 ECHONET Lite 通信ミドルウェア仕様 ４.２.３.５ プロパティ値通知サービス［0x63,0x73,0x53］
+  /// </seealso>
+  public static ValueTask NotifyPropertiesOneWayMulticastAsync(
+    this EchonetObject sourceObject,
+    IEnumerable<byte> notifyPropertyCodes,
+    EOJ destinationObject,
+    CancellationToken cancellationToken = default
+  )
+  {
+    if (sourceObject is null)
+      throw new ArgumentNullException(nameof(sourceObject));
+    if (sourceObject.Node is not EchonetSelfNode)
+      throw CreateCanNotSpecifyOtherNodeAsSource();
+    if (notifyPropertyCodes is null)
+      throw new ArgumentNullException(nameof(notifyPropertyCodes));
+
+    return GetClientServiceOrThrow(sourceObject).NotifyOneWayAsync(
+      sourceObject: sourceObject.EOJ,
+      properties: EnumeratePropertyValues(sourceObject, notifyPropertyCodes),
+      destinationNodeAddress: null, // multicast
+      destinationObject: destinationObject,
+      cancellationToken: cancellationToken
+    );
+  }
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetServicePropertyResult.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetServicePropertyResult.cs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+namespace Smdn.Net.EchonetLite;
+
+/// <summary>
+/// ECHONET Lite サービス（ESV）の要求に対する応答における、個々のプロパティの処理結果を表します。
+/// </summary>
+public enum EchonetServicePropertyResult {
+  /// <summary>
+  /// 要求が受理されたことを表す値を示します。
+  /// プロパティ値の書き込み要求・読み出し要求・通知は行われました。
+  /// </summary>
+  Accepted,
+
+  /// <summary>
+  /// 要求が受理されなかったことを表す値を示します。
+  /// プロパティ値の書き込み要求・読み出し要求・通知は行われませんでした。
+  /// </summary>
+  NotAccepted,
+
+  /// <summary>
+  /// 応答に受理・不受理の結果が含まれなていないことを表す値を示します。
+  /// プロパティ値は処理されませんでした。
+  /// </summary>
+  Unavailable,
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetServiceResponse.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetServiceResponse.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System.Collections.Generic;
+
+namespace Smdn.Net.EchonetLite;
+
+/// <summary>
+/// ECHONET Lite サービス（ESV）の要求に対する応答を記述します。
+/// </summary>
+public readonly struct EchonetServiceResponse {
+  /// <summary>
+  /// 要求に対する応答が成功かどうかを表す<see cref="bool"/>を取得します。
+  /// </summary>
+  /// <value>
+  /// 「応答」の場合は<see langword="true"/>、「不可応答」の場合は<see langword="false"/>を返します。
+  /// </value>
+  public bool IsSuccess { get; init; }
+
+  /// <summary>
+  /// 応答における個々のプロパティ値の処理結果を表す<see cref="EchonetServicePropertyResult"/>を参照するためのディクショナリを取得します。
+  /// </summary>
+  public IReadOnlyDictionary<EchonetProperty, EchonetServicePropertyResult> Properties { get; init; }
+
+  internal EchonetServiceResponse(
+    bool isSuccess,
+    IReadOnlyDictionary<EchonetProperty, EchonetServicePropertyResult> properties
+  )
+  {
+    IsSuccess = isSuccess;
+    Properties = properties;
+  }
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/IEchonetClientService.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/IEchonetClientService.cs
@@ -3,11 +3,15 @@
 #if SYSTEM_TIMEPROVIDER
 using System;
 #endif
+using System.Collections.Generic;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 
 using Smdn.Net.EchonetLite.ComponentModel;
+using Smdn.Net.EchonetLite.Protocol;
 
 namespace Smdn.Net.EchonetLite;
 
@@ -36,4 +40,65 @@ internal interface IEchonetClientService : IEventInvoker {
   /// 自ノードのアドレスを規定できない場合は、<see langword="null"/>を返します。
   /// </returns>
   IPAddress? GetSelfNodeAddress();
+
+  ValueTask RequestWriteOneWayAsync(
+    EOJ sourceObject,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
+    IEnumerable<PropertyValue> properties,
+    CancellationToken cancellationToken
+  );
+
+  ValueTask<EchonetServiceResponse>
+  RequestWriteAsync(
+    EOJ sourceObject,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
+    IEnumerable<PropertyValue> properties,
+    CancellationToken cancellationToken
+  );
+
+  ValueTask<EchonetServiceResponse>
+  RequestReadAsync(
+    EOJ sourceObject,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
+    IEnumerable<byte> propertyCodes,
+    CancellationToken cancellationToken
+  );
+
+  ValueTask<(EchonetServiceResponse SetResponse, EchonetServiceResponse GetResponse)>
+  RequestWriteReadAsync(
+    EOJ sourceObject,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
+    IEnumerable<PropertyValue> propertiesToSet,
+    IEnumerable<byte> propertyCodesToGet,
+    CancellationToken cancellationToken
+  );
+
+  ValueTask RequestNotifyOneWayAsync(
+    EOJ sourceObject,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
+    IEnumerable<byte> propertyCodes,
+    CancellationToken cancellationToken
+  );
+
+  ValueTask NotifyOneWayAsync(
+    EOJ sourceObject,
+    IEnumerable<PropertyValue> properties,
+    IPAddress? destinationNodeAddress,
+    EOJ destinationObject,
+    CancellationToken cancellationToken
+  );
+
+  ValueTask<EchonetServiceResponse>
+  NotifyAsync(
+    EOJ sourceObject,
+    IEnumerable<PropertyValue> properties,
+    IPAddress destinationNodeAddress,
+    EOJ destinationObject,
+    CancellationToken cancellationToken
+  );
 }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetObject.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/UnspecifiedEchonetObject.cs
@@ -66,7 +66,8 @@ internal sealed class UnspecifiedEchonetObject : EchonetObject {
     ESV esv,
     ushort tid,
     PropertyValue value,
-    bool validateValue
+    bool validateValue,
+    bool? newModificationState
   )
   {
     if (!properties.TryGetValue(value.EPC, out var property)) {
@@ -102,7 +103,7 @@ internal sealed class UnspecifiedEchonetObject : EchonetObject {
     // 詳細仕様が未解決・不明なため、プロパティ値の検証はできない
     // if (validateValue) { }
 
-    property.SetValue(esv, tid, value);
+    property.SetValue(esv, tid, value, newModificationState);
 
     return true;
   }

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
@@ -92,7 +92,7 @@ public class EchonetClientTests {
 
     Assert.DoesNotThrow(() => handler.RaiseEDATA2Received(), "frame received after dispose");
 
-    Assert.ThrowsAsync<ObjectDisposedException>(async () => await client.PerformInstanceListNotificationAsync(), "send request after dispose");
+    Assert.ThrowsAsync<ObjectDisposedException>(async () => await client.NotifyInstanceListAsync(), "send request after dispose");
 
     Assert.DoesNotThrow(() => client.Dispose(), "Dispose #2");
     Assert.DoesNotThrowAsync(async () => await client.DisposeAsync(), "DisposeAsync");
@@ -110,7 +110,7 @@ public class EchonetClientTests {
 
     Assert.DoesNotThrow(() => handler.RaiseEDATA2Received(), "frame received after dispose");
 
-    Assert.ThrowsAsync<ObjectDisposedException>(async () => await client.PerformInstanceListNotificationAsync(), "send request after dispose");
+    Assert.ThrowsAsync<ObjectDisposedException>(async () => await client.NotifyInstanceListAsync(), "send request after dispose");
 
     Assert.DoesNotThrowAsync(async () => await client.DisposeAsync(), "DisposeAsync #2");
     Assert.DoesNotThrow(() => client.Dispose(), "Dispose");


### PR DESCRIPTION
### Description
#### EchonetClient
`EchonetClient`では、抽象度の低いAPIを提供する。

送信先アドレス・EOJ・EPCをそのままの値で表すプリミティブな型を引数に取ることで、`EchonetObject`・`EchonetProperty`を使用せずにサービス要求を行えるようにする。

また新たに応答と処理結果を表す`EchonetServiceResponse`を導入し、要応答のサービス要求APIに共通する戻り値型とする。
この型で個々のプロパティの処理結果(受理・不受理・未処理)も表現するが、実装は今後行う。

#### EchonetObjectExtensions
`EchonetObject`では、抽象度の高いAPIを提供する。

送信先アドレス・EOJ・EPCは、`EchonetObject`・`EchonetProperty`を介して指定する。

現時点ではEchonetObjectのメソッドとはせず、暫定的に拡張メソッドとして実装し、今後必要があればインスタンスメソッドとして書き換える。

#### EchonetProperty.HasModified
`EchonetProperty.HasModified`を導入し、プロパティの値が「変更されたが未送信」「送信したが不受理・未処理」の状態を表現できるようにする。

これにより、将来的に、応答不要あるいは一斉同報のSet要求が不受理・未処理となった場合でも、その状態を把握できるようにAPIを用意しておく。
