### PR TITLE
Smdn.Net.EchonetLite.ObjectModelを追加する

### DIFF
--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/DeviceSuperClass.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/DeviceSuperClass.cs
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+/// <summary>
+/// 機器オブジェクトのプロパティに対して、型定義された値としてのアクセス機構を提供する抽象クラスを提供します。
+/// このクラスは機器オブジェクトスーパークラスを表す抽象クラスとして実装され、
+/// 各機器オブジェクトの基本クラスとして使用することができます。
+/// </summary>
+/// <seealso cref="IEchonetDeviceFactory"/>
+/// <seealso href="https://echonet.jp/wp/wp-content/uploads/pdf/General/Standard/Release/Release_R/Appendix_Release_R.pdf">
+/// APPENDIX ECHONET 機器オブジェクト詳細規定 Release R
+/// 第２章 機器オブジェクトスーパークラス規定
+/// </seealso>
+/// <seealso href="https://echonet.jp/spec_mra_rr2/">
+/// Machine Readable Appendix Release R rev.2
+/// </seealso>
+public abstract class DeviceSuperClass : EchonetDevice {
+  protected DeviceSuperClass(
+    byte classGroupCode,
+    byte classCode,
+    byte instanceCode
+  )
+    : base(
+      classGroupCode: classGroupCode,
+      classCode: classCode,
+      instanceCode: instanceCode
+    )
+  {
+    // TODO: use source generator
+    OperationStatus = CreateAccessor(0x80, TryParseOperationStatus);
+    InstallationLocation = CreateAccessor(0x81, TryParseInstallationLocation);
+    Protocol = CreateAccessor(0x82, TryParseProtocol);
+    // TODO: 0x83 ID
+    // TODO: 0x84 InstantaneousElectricPowerConsumption
+    // TODO: 0x85 ConsumedCumulativeElectricEnergy
+    // TODO: 0x86 ManufacturerFaultCode
+    // TODO: 0x87 CurrentLimit
+    FaultStatus = CreateAccessor(0x88, TryParseFaultStatus);
+    // TODO: 0x89 FaultDescription
+    Manufacturer = CreateAccessor(0x8A, TryParseManufacturer);
+    // TODO: 0x8B BusinessFacilityCode
+    // TODO: 0x8C ProductCode
+    SerialNumber = CreateAccessor(0x8D, TryParseSerialNumber);
+    // TODO: 0x8E ProductionDate
+    // TODO: 0x8F PowerSaving
+    // TODO: 0x93 RemoteControl
+    CurrentTimeSetting = CreateAccessor(0x97, TryParseCurrentTimeSetting); // MRA says {"shortName": "DEL"}
+    CurrentDateAndTime = CreateAccessor(0x98, TryParseCurrentDateAndTime);
+    // TODO: 0x99 PowerLimit
+    // TODO: 0x9A HourMeter
+  }
+
+  protected IEchonetPropertyGetAccessor<TValue> CreateAccessor<TValue>(
+    byte propertyCode,
+    EchonetPropertyValueParser<TValue> tryParseValue
+  ) where TValue : notnull
+    => new EchonetPropertyGetAccessor<TValue>(
+      device: this,
+      propertyCode: propertyCode,
+      tryParseValue: tryParseValue
+    );
+
+  protected IEchonetPropertySetGetAccessor<TValue> CreateAccessor<TValue>(
+    byte propertyCode,
+    EchonetPropertyValueParser<TValue> tryParseValue,
+    EchonetPropertyValueFormatter<TValue> formatValue
+  ) where TValue : notnull
+    => new EchonetPropertySetGetAccessor<TValue>(
+      device: this,
+      propertyCode: propertyCode,
+      tryParseValue: tryParseValue,
+      formatValue: formatValue
+    );
+
+  /// <summary>
+  /// ECHONETプロパティ「動作状態」(EPC <c>0x80</c>)の値を、<see cref="bool"/>として取得します。
+  /// </summary>
+  /// <value>
+  /// <see langword="true"/>の場合はON、<see langword="false"/>の場合はOFFを表します。
+  /// </value>
+  /// <seealso href="https://echonet.jp/wp/wp-content/uploads/pdf/General/Standard/Release/Release_R/Appendix_Release_R.pdf">
+  /// APPENDIX ECHONET 機器オブジェクト詳細規定 Release R
+  /// 第２章 機器オブジェクトスーパークラス規定
+  /// </seealso>
+  public IEchonetPropertyGetAccessor<bool> OperationStatus { get; }
+
+  private static readonly EchonetPropertyValueParser<bool> TryParseOperationStatus
+    = static (ReadOnlySpan<byte> data, out bool value) =>
+      {
+        (var ret, value) = data[0] switch {
+          0x30 => (true, true),
+          0x31 => (true, false),
+          _ => (false, default),
+        };
+
+        return ret;
+      };
+
+  /// <summary>
+  /// ECHONETプロパティ「設置場所」(EPC <c>0x81</c>)の値を、<see cref="byte"/>として取得します。
+  /// </summary>
+  /// <value>
+  /// 値の詳細は「ECHONET 機器オブジェクト詳細規定」を参照してください。
+  /// </value>
+  /// <seealso href="https://echonet.jp/wp/wp-content/uploads/pdf/General/Standard/Release/Release_R/Appendix_Release_R.pdf">
+  /// APPENDIX ECHONET 機器オブジェクト詳細規定 Release R
+  /// 第２章 機器オブジェクトスーパークラス規定
+  /// </seealso>
+  public IEchonetPropertyGetAccessor<byte> InstallationLocation { get; }
+
+  private static readonly EchonetPropertyValueParser<byte> TryParseInstallationLocation
+    = static (ReadOnlySpan<byte> data, out byte value) =>
+      {
+        value = data[0];
+
+        return true;
+      };
+
+  /// <summary>
+  /// ECHONETプロパティ「規格 Version 情報」(EPC <c>0x82</c>)の値を取得します。
+  /// </summary>
+  /// <value>
+  /// <see cref="ValueTuple{String,Int32}"/>の1番目の要素はAPPENDIXのRelease順を表す<see cref="string"/>、
+  /// 2番目の要素はリビジョン番号を表す<see cref="int"/>です。
+  /// </value>
+  /// <seealso href="https://echonet.jp/wp/wp-content/uploads/pdf/General/Standard/Release/Release_R/Appendix_Release_R.pdf">
+  /// APPENDIX ECHONET 機器オブジェクト詳細規定 Release R
+  /// 第２章 機器オブジェクトスーパークラス規定
+  /// </seealso>
+  public IEchonetPropertyGetAccessor<(string Release, int Revision)> Protocol { get; }
+
+  private static readonly EchonetPropertyValueParser<(string Release, int Revision)> TryParseProtocol
+    = static (ReadOnlySpan<byte> data, out (string Release, int Revision) value) =>
+      {
+        value = (
+          Release: new string((char)data[2], 1),
+          Revision: data[3]
+        );
+
+        return true;
+      };
+
+  /// <summary>
+  /// ECHONETプロパティ「異常発生状態」(EPC <c>0x88</c>)の値を、<see cref="bool"/>として取得します。
+  /// </summary>
+  /// <value>
+  /// <see langword="true"/>の場合は異常発生有、<see langword="false"/>の場合は異常発生無を表します。
+  /// </value>
+  /// <seealso href="https://echonet.jp/wp/wp-content/uploads/pdf/General/Standard/Release/Release_R/Appendix_Release_R.pdf">
+  /// APPENDIX ECHONET 機器オブジェクト詳細規定 Release R
+  /// 第２章 機器オブジェクトスーパークラス規定
+  /// </seealso>
+  public IEchonetPropertyGetAccessor<bool> FaultStatus { get; }
+
+  private static readonly EchonetPropertyValueParser<bool> TryParseFaultStatus
+    = static (ReadOnlySpan<byte> data, out bool value) =>
+      {
+        (var ret, value) = data[0] switch {
+          0x41 => (true, true),
+          0x42 => (true, false),
+          _ => (false, default),
+        };
+
+        return ret;
+      };
+
+  /// <summary>
+  /// ECHONETプロパティ「メーカコード」(EPC <c>0x8A</c>)の値を、<see cref="int"/>として取得します。
+  /// </summary>
+  /// <value>
+  /// 値の詳細は「<see href="https://echonet.jp/wp/wp-content/uploads/pdf/General/Echonet/ManufacturerCode/list_code.pdf">発行済メーカコード一覧</see>」を参照してください。
+  /// </value>
+  /// <seealso href="https://echonet.jp/wp/wp-content/uploads/pdf/General/Echonet/ManufacturerCode/list_code.pdf">
+  /// 発行済メーカコード一覧
+  /// </seealso>
+  /// <seealso href="https://echonet.jp/wp/wp-content/uploads/pdf/General/Standard/Release/Release_R/Appendix_Release_R.pdf">
+  /// APPENDIX ECHONET 機器オブジェクト詳細規定 Release R
+  /// 第２章 機器オブジェクトスーパークラス規定
+  /// </seealso>
+  public IEchonetPropertyGetAccessor<int> Manufacturer { get; }
+
+  private static readonly EchonetPropertyValueParser<int> TryParseManufacturer
+    = static (ReadOnlySpan<byte> data, out int value) =>
+      {
+        value = (data[0] << 16) | (data[1] << 8) | data[2];
+
+        return true;
+      };
+
+  /// <summary>
+  /// ECHONETプロパティ「製造番号」(EPC <c>0x8D</c>)の値を、<see cref="string"/>として取得します。
+  /// </summary>
+  /// <value>
+  /// 「製造番号」を表す<see cref="string"/>の値。
+  /// </value>
+  /// <seealso href="https://echonet.jp/wp/wp-content/uploads/pdf/General/Standard/Release/Release_R/Appendix_Release_R.pdf">
+  /// APPENDIX ECHONET 機器オブジェクト詳細規定 Release R
+  /// 第２章 機器オブジェクトスーパークラス規定
+  /// </seealso>
+  public IEchonetPropertyGetAccessor<string> SerialNumber { get; }
+
+  private static readonly EchonetPropertyValueParser<string> TryParseSerialNumber
+    = static (ReadOnlySpan<byte> data, out string value) =>
+      {
+        value = Encoding.ASCII.GetString(data).TrimEnd(); // trim null terminator etc.
+
+        return true;
+      };
+
+  /// <summary>
+  /// ECHONETプロパティ「現在時刻設定」(EPC <c>0x97</c>)の値を、<see cref="TimeSpan"/>として取得します。
+  /// </summary>
+  /// <value>
+  /// 「現在時刻設定」を表す<see cref="TimeSpan"/>の値。
+  /// </value>
+  /// <seealso href="https://echonet.jp/wp/wp-content/uploads/pdf/General/Standard/Release/Release_R/Appendix_Release_R.pdf">
+  /// APPENDIX ECHONET 機器オブジェクト詳細規定 Release R
+  /// 第２章 機器オブジェクトスーパークラス規定
+  /// </seealso>
+  public IEchonetPropertyGetAccessor<TimeSpan> CurrentTimeSetting { get; }
+
+  private static readonly EchonetPropertyValueParser<TimeSpan> TryParseCurrentTimeSetting
+    = static (ReadOnlySpan<byte> data, out TimeSpan value) =>
+      {
+        // TODO: validation
+        value = new(
+          hours: data[0],
+          minutes: data[1],
+          seconds: 0
+        );
+
+        return true;
+      };
+
+  /// <summary>
+  /// ECHONETプロパティ「現在年月日設定」(EPC <c>0x98</c>)の値を、<see cref="DateTime"/>として取得します。
+  /// </summary>
+  /// <value>
+  /// 「現在年月日設定」を表す<see cref="DateTime"/>の値。　<see cref="DateTime.Year"/>、<see cref="DateTime.Month"/>および
+  /// <see cref="DateTime.Day"/>のみが設定され、それ以外の値は意味を持ちません。
+  /// </value>
+  /// <seealso href="https://echonet.jp/wp/wp-content/uploads/pdf/General/Standard/Release/Release_R/Appendix_Release_R.pdf">
+  /// APPENDIX ECHONET 機器オブジェクト詳細規定 Release R
+  /// 第２章 機器オブジェクトスーパークラス規定
+  /// </seealso>
+  public IEchonetPropertyGetAccessor<DateTime> CurrentDateAndTime { get; }
+
+  private static readonly EchonetPropertyValueParser<DateTime> TryParseCurrentDateAndTime
+    = static (ReadOnlySpan<byte> data, out DateTime value) =>
+      {
+        // TODO: validation
+        value = new(
+          year: BinaryPrimitives.ReadInt16BigEndian(data),
+          month: data[2],
+          day: data[3]
+        );
+
+        return true;
+      };
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyAccessor.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyAccessor.cs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+internal abstract class EchonetPropertyAccessor : IEchonetPropertyAccessor {
+  protected EchonetDevice Device { get; }
+
+  public byte PropertyCode { get; }
+
+  public bool IsAvailable => Device.Properties.ContainsKey(PropertyCode);
+
+  public EchonetProperty BaseProperty => Device.Properties.TryGetValue(PropertyCode, out var p)
+    ? p
+    : throw new EchonetPropertyNotAvailableException(Device, PropertyCode);
+
+  private protected EchonetPropertyAccessor(EchonetDevice device, byte propertyCode)
+  {
+    Device = device ?? throw new ArgumentNullException(nameof(device));
+    PropertyCode = propertyCode;
+  }
+
+  /// <summary>
+  /// <see cref="EchonetProperty"/>に格納されているプロパティ値を、任意の型<typeparamref name="TValue"/>のオブジェクトに変換します。
+  /// </summary>
+  /// <param name="property">変換するプロパティ値を格納している<see cref="EchonetProperty"/>。</param>
+  /// <param name="tryParseValue">プロパティ値を表すバイト列を、任意の型<typeparamref name="TValue"/>のオブジェクトに変換するメソッドへのデリゲート。</param>
+  /// <param name="value">バイト列から変換された<typeparamref name="TValue"/>。</param>
+  /// <returns>変換できた場合は<see langword="true"/>、そうでない場合は<see langword="false"/>。</returns>
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="property"/>が<see langword="null"/>です。
+  /// または、<paramref name="tryParseValue"/>が<see langword="null"/>です。
+  /// </exception>
+  /// <remarks>
+  /// プロパティ値を表すバイト列の長さが0の場合、<paramref name="tryParseValue"/>の呼び出しは行わず、常に<see langword="false"/>を返します。
+  /// </remarks>
+  private protected static bool TryParsePropertyValue<TValue>(
+    EchonetProperty property,
+    EchonetPropertyValueParser<TValue> tryParseValue,
+    out TValue value
+  ) where TValue : notnull
+  {
+    if (property is null)
+      throw new ArgumentNullException(nameof(property));
+    if (tryParseValue is null)
+      throw new ArgumentNullException(nameof(tryParseValue));
+
+    value = default!;
+
+    return !property.ValueSpan.IsEmpty && tryParseValue(property.ValueSpan, out value);
+  }
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyGetAccessor.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyGetAccessor.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+#pragma warning disable IDE0055
+internal sealed class EchonetPropertyGetAccessor<TValue> :
+  EchonetPropertyAccessor,
+  IEchonetPropertyGetAccessor<TValue>
+  where TValue : notnull
+{
+#pragma warning restore IDE0055
+  private readonly EchonetPropertyValueParser<TValue> tryParseValue;
+
+  public TValue Value
+    => IsAvailable
+      ? TryParsePropertyValue(BaseProperty, tryParseValue, out var value)
+        ? value
+        : throw new EchonetPropertyInvalidValueException(Device, BaseProperty)
+      : throw new EchonetPropertyNotAvailableException(Device, PropertyCode);
+
+  internal EchonetPropertyGetAccessor(
+    EchonetDevice device,
+    byte propertyCode,
+    EchonetPropertyValueParser<TValue> tryParseValue
+  )
+    : base(device, propertyCode)
+  {
+    this.tryParseValue = tryParseValue ?? throw new ArgumentNullException(nameof(tryParseValue));
+  }
+
+  public bool TryGetValue(out TValue value)
+  {
+    value = default!;
+
+    return IsAvailable && TryParsePropertyValue(BaseProperty, tryParseValue, out value);
+  }
+
+  public override string ToString()
+    => TryGetValue(out var value)
+      ? $"{Device} 0x{PropertyCode:X2}: {value}"
+      : $"{Device} 0x{PropertyCode:X2}: {(IsAvailable ? "❓" : "🚫")}";
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyInvalidValueException.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyInvalidValueException.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+public class EchonetPropertyInvalidValueException : InvalidOperationException {
+  public EchonetObject? DeviceObject { get; }
+  public EchonetProperty? Property { get; }
+
+  public EchonetPropertyInvalidValueException()
+  {
+  }
+
+  public EchonetPropertyInvalidValueException(
+    EchonetObject deviceObject,
+    EchonetProperty property
+  )
+    : this(message: $"invalid property value (Object: {deviceObject}, Property: {property})")
+  {
+    DeviceObject = deviceObject;
+    Property = property;
+  }
+
+  public EchonetPropertyInvalidValueException(string? message)
+    : base(message)
+  {
+  }
+
+  public EchonetPropertyInvalidValueException(string? message, Exception? innerException)
+    : base(message, innerException)
+  {
+  }
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyNotAvailableException.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyNotAvailableException.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+public class EchonetPropertyNotAvailableException : InvalidOperationException {
+  public EchonetObject? DeviceObject { get; }
+  public byte? PropertyCode { get; }
+
+  public EchonetPropertyNotAvailableException()
+  {
+  }
+
+  public EchonetPropertyNotAvailableException(
+    EchonetObject deviceObject,
+    byte propertyCode
+  )
+    : this(message: $"property not available (Object: {deviceObject}, EPC: 0x{propertyCode:X2})")
+  {
+    DeviceObject = deviceObject;
+    PropertyCode = propertyCode;
+  }
+
+  public EchonetPropertyNotAvailableException(string? message)
+    : base(message)
+  {
+  }
+
+  public EchonetPropertyNotAvailableException(string? message, Exception? innerException)
+    : base(message, innerException)
+  {
+  }
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertySetGetAccessor.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertySetGetAccessor.cs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+#pragma warning disable IDE0055
+internal sealed class EchonetPropertySetGetAccessor<TValue> :
+  EchonetPropertyAccessor,
+  IEchonetPropertySetGetAccessor<TValue>
+  where TValue : notnull
+{
+#pragma warning restore IDE0055
+  private readonly EchonetPropertyValueParser<TValue> tryParseValue;
+  private readonly EchonetPropertyValueFormatter<TValue> formatValue;
+
+  public TValue Value {
+    get => IsAvailable
+      ? TryParsePropertyValue(BaseProperty, tryParseValue, out var value)
+        ? value
+        : throw new EchonetPropertyInvalidValueException(Device, BaseProperty)
+      : throw new EchonetPropertyNotAvailableException(Device, PropertyCode);
+
+    set {
+      if (!IsAvailable)
+        throw new EchonetPropertyNotAvailableException(Device, PropertyCode);
+
+      BaseProperty.WriteValue(
+        writer => formatValue(writer, value),
+        raiseValueChangedEvent: false,
+        setLastUpdatedTime: false
+      );
+    }
+  }
+
+  internal EchonetPropertySetGetAccessor(
+    EchonetDevice device,
+    byte propertyCode,
+    EchonetPropertyValueParser<TValue> tryParseValue,
+    EchonetPropertyValueFormatter<TValue> formatValue
+  )
+    : base(device, propertyCode)
+  {
+    this.tryParseValue = tryParseValue ?? throw new ArgumentNullException(nameof(tryParseValue));
+    this.formatValue = formatValue ?? throw new ArgumentNullException(nameof(formatValue));
+  }
+
+  public bool TryGetValue(out TValue value)
+  {
+    value = default!;
+
+    return IsAvailable && TryParsePropertyValue(BaseProperty, tryParseValue, out value);
+  }
+
+  public override string ToString()
+    => TryGetValue(out var value)
+      ? $"{Device} 0x{PropertyCode:X2}: {value}"
+      : $"{Device} 0x{PropertyCode:X2}: {(IsAvailable ? "❓" : "🚫")}";
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyValueFormatter.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyValueFormatter.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Buffers;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+/// <summary>
+/// 任意の型<typeparamref name="TValue"/>のオブジェクトを、ECHONET プロパティの値として格納するバイト列へ変換するメソッドを表します。
+/// </summary>
+/// <typeparam name="TValue">プロパティ値に変換する前の型。</typeparam>
+/// <param name="writer"><typeparamref name="TValue"/>の値をバイト列に変換して書き込むための書き込み先となる<see cref="IBufferWriter{Byte}"/>。</param>
+/// <param name="value">プロパティ値として書き込まれる、変換前の値。</param>
+/// <exception cref="InvalidOperationException">不正な値を書き込もうとしました。</exception>
+public delegate void EchonetPropertyValueFormatter<in TValue>(
+  IBufferWriter<byte> writer,
+  TValue value
+) where TValue : notnull;

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyValueParser.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertyValueParser.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+/// <summary>
+/// ECHONET プロパティの値を表すバイト列から、任意の型<typeparamref name="TValue"/>への変換を試行するメソッドを表します。
+/// </summary>
+/// <typeparam name="TValue">プロパティ値の変換後の型。</typeparam>
+/// <param name="data">バイト列形式のプロパティ値を表す<see cref="ReadOnlySpan{Byte}"/>。</param>
+/// <param name="value">バイト列から変換された<typeparamref name="TValue"/>。</param>
+/// <returns>
+/// 変換できた場合は<see langword="true"/>、
+/// 不正なバイト列・値域外などの理由で変換できなかった場合は<see langword="false"/>。
+/// </returns>
+public delegate bool EchonetPropertyValueParser<TValue>(
+  ReadOnlySpan<byte> data,
+  out TValue value
+) where TValue : notnull;

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/IEchonetPropertyAccessor.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/IEchonetPropertyAccessor.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+/// <summary>
+/// ECHONET プロパティとのバインディングを行い、ECHONET プロパティを.NET CLRと親和性のあるオブジェクトモデルで
+/// 参照・実装するための機構を提供します。
+/// </summary>
+/// <seealso cref="IEchonetPropertyGetAccessor{TValue}"/>
+/// <seealso cref="IEchonetPropertySetGetAccessor{TValue}"/>
+public interface IEchonetPropertyAccessor {
+  /// <summary>
+  /// このインスタンスに関連付けられているECHONET プロパティのプロパティコード(EPC)を取得します。
+  /// </summary>
+  byte PropertyCode { get; }
+
+  /// <summary>
+  /// ECHONET オブジェクトにこのプロパティが具備されている、
+  /// かつプロパティが取得済みであるかどうかを表す<see cref="bool"/>値を取得します。
+  /// </summary>
+  bool IsAvailable { get; }
+
+  /// <summary>
+  /// このインスタンスに関連付けられているECHONET プロパティを表す<see cref="EchonetProperty"/>を取得します。
+  /// </summary>
+  /// <exception cref="EchonetPropertyNotAvailableException">
+  /// 対応するECHONET プロパティがECHONET オブジェクトに存在していないか、プロパティが未取得です。
+  /// </exception>
+  EchonetProperty BaseProperty { get; }
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/IEchonetPropertyGetAccessor.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/IEchonetPropertyGetAccessor.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+/// <summary>
+/// ECHONET プロパティとのバインディングを行い、ECHONET プロパティおよびその値を.NET CLRと親和性のある
+/// オブジェクトモデルで参照・実装するための機構を提供します。
+/// また、Getアクセス可能なECHONET プロパティから、その値を変換・取得する機能を提供します。
+/// </summary>
+/// <typeparam name="TValue">ECHONET プロパティの値と対応させる.NET型。</typeparam>
+public interface IEchonetPropertyGetAccessor<TValue> : IEchonetPropertyAccessor {
+  /// <summary>
+  /// 現在のECHONET プロパティの値を<typeparamref name="TValue"/>に変換した値を取得します。
+  /// </summary>
+  /// <exception cref="EchonetPropertyInvalidValueException">
+  /// 現在のECHONET プロパティの値を<typeparamref name="TValue"/>に変換することができません。
+  /// </exception>
+  /// <exception cref="EchonetPropertyNotAvailableException">
+  /// ECHONET プロパティの値が未取得か、サイズが0です。
+  /// または、対応するECHONET プロパティが存在しません。
+  /// </exception>
+  TValue Value { get; }
+
+  /// <summary>
+  /// 現在のECHONET プロパティの値から<typeparamref name="TValue"/>への変換を試みます。
+  /// </summary>
+  /// <param name="value">
+  /// 現在のECHONET プロパティの値を<typeparamref name="TValue"/>に変換した値を格納する出力パラメータ。
+  /// </param>
+  /// <returns>変換できた場合は<see langword="true"/>、そうでない場合は<see langword="false"/>。</returns>
+  bool TryGetValue(out TValue value);
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/IEchonetPropertySetGetAccessor.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/IEchonetPropertySetGetAccessor.cs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+/// <summary>
+/// ECHONET プロパティとのバインディングを行い、ECHONET プロパティおよびその値を.NET CLRと親和性のある
+/// オブジェクトモデルで参照・実装するための機構を提供します。
+/// また、Set/Getアクセス可能なECHONET プロパティに対して、その値を変換・取得・設定する機能を提供します。
+/// </summary>
+/// <typeparam name="TValue">ECHONET プロパティの値と対応させる.NET型。</typeparam>
+public interface IEchonetPropertySetGetAccessor<TValue> : IEchonetPropertyGetAccessor<TValue> {
+  /// <summary>
+  /// 現在のECHONET プロパティの値を<typeparamref name="TValue"/>に変換した値を取得または設定します。
+  /// </summary>
+  /// <exception cref="EchonetPropertyInvalidValueException">
+  /// 現在のECHONET プロパティの値を<typeparamref name="TValue"/>に変換することができません。
+  /// </exception>
+  /// <exception cref="EchonetPropertyNotAvailableException">
+  /// ECHONET プロパティの値が未取得か、サイズが0です。
+  /// または、対応するECHONET プロパティが存在しません。
+  /// </exception>
+  new TValue Value { get; set; }
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/MeasurementValue.TValue.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/MeasurementValue.TValue.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+/// <summary>
+/// 特定の日時における計測値を表す構造体です。
+/// 計測値を表す<typeparamref name="TValue"/>と、計測値を計測した日時を表す<see cref="DateTime"/>の組み合わせを保持します。
+/// </summary>
+/// <typeparam name="TValue">計測値を表す型。</typeparam>
+public readonly struct MeasurementValue<TValue>(TValue value, DateTime measuredAt) where TValue : struct {
+  /// <summary>
+  /// <see cref="MeasurementValue{TValue}"/>の計測値を表す<typeparamref name="TValue"/>。
+  /// </summary>
+  public TValue Value { get; } = value;
+
+  /// <summary>
+  /// <see cref="MeasurementValue{TValue}"/>の計測値を計測した日時を表す<see cref="DateTime"/>。
+  /// </summary>
+  public DateTime MeasuredAt { get; } = measuredAt;
+
+  /// <summary>
+  /// この<see cref="MeasurementValue{TValue}"/>インスタンスを<typeparamref name="TValue"/>と<see cref="DateTime"/>に分解します。
+  /// </summary>
+  /// <param name="value">このインスタンスの<see cref="Value"/>の値が格納される出力パラメータ。</param>
+  /// <param name="measuredAt">このインスタンスの<see cref="MeasuredAt"/>の値が格納される出力パラメータ。</param>
+  public void Deconstruct(
+    out TValue value,
+    out DateTime measuredAt
+  )
+  {
+    value = Value;
+    measuredAt = MeasuredAt;
+  }
+
+  public override string ToString()
+    => $"{Value} ({MeasuredAt})";
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/MeasurementValue.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/MeasurementValue.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+/// <summary>
+/// <see cref="MeasurementValue{TValue}"/>のインスタンスを作成するメソッドを提供します。
+/// </summary>
+public static class MeasurementValue {
+  /// <summary>
+  /// <see cref="MeasurementValue{TValue}"/>のインスタンスを作成します。
+  /// </summary>
+  /// <typeparam name="TValue">計測値を表す型。</typeparam>
+  /// <param name="value"><see cref="MeasurementValue{TValue}.Value"/>に設定する値。</param>
+  /// <param name="measuredAt"><see cref="MeasurementValue{TValue}.MeasuredAt"/>に設定する値。</param>
+  /// <returns>作成した<see cref="MeasurementValue{TValue}"/>インスタンス。</returns>
+  public static MeasurementValue<TValue> Create<TValue>(TValue value, DateTime measuredAt) where TValue : struct
+    => new(value, measuredAt);
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/IEchonetDeviceFactory.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/IEchonetDeviceFactory.cs
@@ -8,6 +8,7 @@ namespace Smdn.Net.EchonetLite;
 /// </summary>
 /// <seealso cref="EchonetDevice"/>
 /// <seealso cref="EchonetOtherNode.Devices"/>
+/// <seealso cref="ObjectModel.DeviceSuperClass"/>
 public interface IEchonetDeviceFactory {
   /// <summary>
   /// 指定されたコードに対応する機器オブジェクトを表す<see cref="EchonetDevice"/>を作成します。

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/MeasurementValue.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/MeasurementValue.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using NUnit.Framework;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+[TestFixture]
+public class MeasurementValueTests {
+  [Test]
+  public void Ctor()
+  {
+    var dateTime = DateTime.Now;
+    var val = new MeasurementValue<int>(42, dateTime);
+
+    Assert.That(val.MeasuredAt, Is.EqualTo(dateTime));
+    Assert.That(val.Value, Is.EqualTo(42));
+  }
+
+  [Test]
+  public void Create()
+  {
+    var dateTime = DateTime.Now;
+    var val = MeasurementValue.Create(42.0, dateTime);
+
+    Assert.That(val.MeasuredAt, Is.EqualTo(dateTime));
+    Assert.That(val.Value, Is.EqualTo(42.0));
+  }
+
+  [Test]
+  public void Deconstruct()
+  {
+    var dateTime = DateTime.Now;
+    var val = new MeasurementValue<int>(42, dateTime);
+
+    var (value, measuredAt) = val;
+
+    Assert.That(measuredAt, Is.EqualTo(dateTime));
+    Assert.That(value, Is.EqualTo(42));
+  }
+}


### PR DESCRIPTION
### Description
新たな名前空間`Smdn.Net.EchonetLite.ObjectModel`を導入する。

この名前空間では、ECHONET Liteのオブジェクト・プロパティを、.NETの型システムに寄せて表現する機構を提供する。
  
#### `IEchonetPropertyAccessor`および派生インターフェイス・実装クラス
ECHONETプロパティとのバインディングおよび、ECHONETプロパティ値への型付けされたアクセス機構を提供する。

#### `DeviceSuperClass`
機器オブジェクトスーパークラスを表す抽象クラスを定義し、また上記のインターフェイスを用いたプロパティアクセス機構を提供する。

#### `MeasurementValue<TValue>`
任意の型の値`TValue`と`DateTime`の組み合わせを保持して、「特定の日時における計測値」を表現するための汎用的な型を提供する。