### PR TITLE
Release main/Smdn.Net.EchonetLite.RouteB-2.0.0-preview3

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-net6.0.apilist.cs
@@ -1,72 +1,139 @@
-// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview2)
+// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview3)
 //   Name: Smdn.Net.EchonetLite.RouteB
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview2+c9161acca48757584c059440b4e2b704c3a80505
+//   InformationalVersion: 2.0.0-preview3+2612dc0eb7dba458048cbe65c5e156d272f8ee87
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
-//     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
+//     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Smdn.Net.EchonetLite, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.Primitives, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
+//     System.Collections, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.ComponentModel, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Linq, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Memory, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Net.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Runtime, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 #nullable enable annotations
 
 using System;
-using System.Buffers;
-using System.Net;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Smdn.Net.EchonetLite;
+using Smdn.Net.EchonetLite.ObjectModel;
+using Smdn.Net.EchonetLite.RouteB;
 using Smdn.Net.EchonetLite.RouteB.Credentials;
 using Smdn.Net.EchonetLite.RouteB.Transport;
-using Smdn.Net.EchonetLite.Transport;
+
+namespace Smdn.Net.EchonetLite.RouteB {
+  public class HemsController :
+    IAsyncDisposable,
+    IDisposable,
+    IRouteBCredentialIdentity
+  {
+    public HemsController(IRouteBEchonetLiteHandlerFactory echonetLiteHandlerFactory, IRouteBCredentialProvider routeBCredentialProvider, ILoggerFactory? loggerFactory = null) {}
+    public HemsController(IServiceProvider serviceProvider) {}
+
+    protected EchonetClient Client { get; }
+    public EchonetObject Controller { get; }
+    [MemberNotNullWhen(false, "echonetLiteHandler")]
+    protected bool IsDisposed { [MemberNotNullWhen(false, "echonetLiteHandler")] get; }
+    public LowVoltageSmartElectricEnergyMeter SmartMeter { get; }
+    public TimeSpan TimeoutWaitingProactiveNotification { get; set; }
+    public TimeSpan TimeoutWaitingResponse1 { get; set; }
+    public TimeSpan TimeoutWaitingResponse2 { get; set; }
+
+    public ValueTask ConnectAsync(CancellationToken cancellationToken = default) {}
+    public async ValueTask DisconnectAsync(CancellationToken cancellationToken = default) {}
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    public async ValueTask DisposeAsync() {}
+    protected virtual async ValueTask DisposeAsyncCore() {}
+    [MemberNotNull("client")]
+    [MemberNotNull("Client")]
+    [MemberNotNull("smartMeterObject")]
+    [MemberNotNull("controllerObject")]
+    protected void ThrowIfDisconnected() {}
+  }
+
+  public sealed class LowVoltageSmartElectricEnergyMeter : DeviceSuperClass {
+    public IEchonetPropertyGetAccessor<int> Coefficient { get; }
+    public IEchonetPropertyGetAccessor<IReadOnlyList<(MeasurementValue<ElectricEnergyValue> NormalDirection, MeasurementValue<ElectricEnergyValue> ReverseDirection)>> CumulativeElectricEnergyLog2 { get; }
+    public IEchonetPropertySetGetAccessor<DateTime> DayForTheHistoricalDataOfCumulativeElectricEnergy1 { get; }
+    public IEchonetPropertySetGetAccessor<(DateTime DateAndTime, int NumberOfItems)> DayForTheHistoricalDataOfCumulativeElectricEnergy2 { get; }
+    public IEchonetPropertyGetAccessor<(ElectricCurrentValue RPhase, ElectricCurrentValue TPhase)> InstantaneousCurrent { get; }
+    public IEchonetPropertyGetAccessor<int> InstantaneousElectricPower { get; }
+    public IEchonetPropertyGetAccessor<ElectricEnergyValue> NormalDirectionCumulativeElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<MeasurementValue<ElectricEnergyValue>> NormalDirectionCumulativeElectricEnergyAtEvery30Min { get; }
+    public IEchonetPropertyGetAccessor<IReadOnlyList<MeasurementValue<ElectricEnergyValue>>> NormalDirectionCumulativeElectricEnergyLog1 { get; }
+    public IEchonetPropertyGetAccessor<int> NumberOfEffectiveDigitsCumulativeElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<(MeasurementValue<ElectricEnergyValue> NormalDirection, MeasurementValue<ElectricEnergyValue> ReverseDirection)> OneMinuteMeasuredCumulativeAmountsOfElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<ElectricEnergyValue> ReverseDirectionCumulativeElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<MeasurementValue<ElectricEnergyValue>> ReverseDirectionCumulativeElectricEnergyAtEvery30Min { get; }
+    public IEchonetPropertyGetAccessor<IReadOnlyList<MeasurementValue<ElectricEnergyValue>>> ReverseDirectionCumulativeElectricEnergyLog1 { get; }
+    public IEchonetPropertyGetAccessor<ReadOnlyMemory<byte>> RouteBIdentificationNumber { get; }
+    public IEchonetPropertyGetAccessor<decimal> UnitForCumulativeElectricEnergy { get; }
+  }
+
+  public static class MeasurementValue {
+    public static MeasurementValue<TValue> Create<TValue>(TValue @value, DateTime measuredAt) where TValue : struct {}
+  }
+
+  public sealed class RouteBDeviceFactory : IEchonetDeviceFactory {
+    public static RouteBDeviceFactory Instance { get; }
+
+    public RouteBDeviceFactory() {}
+
+    public EchonetDevice? Create(byte classGroupCode, byte classCode, byte instanceCode) {}
+  }
+
+  public readonly struct ElectricCurrentValue {
+    public decimal Amperes { get; }
+    public bool IsValid { get; }
+    public short RawValue { get; }
+
+    public override string ToString() {}
+  }
+
+  public readonly struct ElectricEnergyValue {
+    public static readonly ElectricEnergyValue NoMeasurementData; // = "(no data)"
+    public static readonly ElectricEnergyValue Zero; // = "0 [kWh]"
+
+    public bool IsValid { get; }
+    public decimal KiloWattHours { get; }
+    public int RawValue { get; }
+    public decimal WattHours { get; }
+
+    public override string ToString() {}
+    public bool TryGetValueAsKiloWattHours(out decimal @value) {}
+  }
+
+  public readonly struct MeasurementValue<TValue> where TValue : struct {
+    public MeasurementValue(TValue @value, DateTime measuredAt) {}
+
+    public DateTime MeasuredAt { get; }
+    public TValue Value { get; }
+
+    public void Deconstruct(out TValue @value, out DateTime measuredAt) {}
+    public override string ToString() {}
+  }
+}
 
 namespace Smdn.Net.EchonetLite.RouteB.Credentials {
-  public interface IRouteBCredential : IDisposable {
-    void WriteIdTo(IBufferWriter<byte> buffer);
-    void WritePasswordTo(IBufferWriter<byte> buffer);
-  }
-
-  public interface IRouteBCredentialIdentity {
-  }
-
-  public interface IRouteBCredentialProvider {
-    IRouteBCredential GetCredential(IRouteBCredentialIdentity identity);
-  }
-
   public static class RouteBCredentialServiceCollectionExtensions {
     public static IServiceCollection AddRouteBCredential(this IServiceCollection services, string id, string password) {}
     public static IServiceCollection AddRouteBCredentialFromEnvironmentVariable(this IServiceCollection services, string envVarForId, string envVarForPassword) {}
     public static IServiceCollection AddRouteBCredentialProvider(this IServiceCollection services, IRouteBCredentialProvider credentialProvider) {}
   }
-
-  public static class RouteBCredentials {
-    public const int AuthenticationIdLength = 32;
-    public const int PasswordLength = 12;
-  }
 }
 
 namespace Smdn.Net.EchonetLite.RouteB.Transport {
-  public interface IRouteBEchonetLiteHandlerBuilder {
-    IServiceCollection Services { get; }
-  }
-
-  public interface IRouteBEchonetLiteHandlerFactory {
-    ValueTask<RouteBEchonetLiteHandler> CreateAsync(CancellationToken cancellationToken);
-  }
-
-  public abstract class RouteBEchonetLiteHandler : EchonetLiteHandler {
-    protected RouteBEchonetLiteHandler() {}
-
-    public abstract IPAddress? PeerAddress { get; }
-
-    public ValueTask ConnectAsync(IRouteBCredential credential, CancellationToken cancellationToken = default) {}
-    protected abstract ValueTask ConnectAsyncCore(IRouteBCredential credential, CancellationToken cancellationToken);
-    public ValueTask DisconnectAsync(CancellationToken cancellationToken = default) {}
-    protected abstract ValueTask DisconnectAsyncCore(CancellationToken cancellationToken);
-  }
-
   public static class RouteBEchonetLiteHandlerBuilderServiceCollectionExtensions {
     public static IServiceCollection AddRouteBHandler(this IServiceCollection services, Action<IRouteBEchonetLiteHandlerBuilder> configure) {}
   }

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-net8.0.apilist.cs
@@ -1,72 +1,139 @@
-// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview2)
+// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview3)
 //   Name: Smdn.Net.EchonetLite.RouteB
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview2+c9161acca48757584c059440b4e2b704c3a80505
+//   InformationalVersion: 2.0.0-preview3+2612dc0eb7dba458048cbe65c5e156d272f8ee87
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
-//     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
+//     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Smdn.Net.EchonetLite, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.Primitives, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
+//     System.Collections, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Linq, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Memory, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Net.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 #nullable enable annotations
 
 using System;
-using System.Buffers;
-using System.Net;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Smdn.Net.EchonetLite;
+using Smdn.Net.EchonetLite.ObjectModel;
+using Smdn.Net.EchonetLite.RouteB;
 using Smdn.Net.EchonetLite.RouteB.Credentials;
 using Smdn.Net.EchonetLite.RouteB.Transport;
-using Smdn.Net.EchonetLite.Transport;
+
+namespace Smdn.Net.EchonetLite.RouteB {
+  public class HemsController :
+    IAsyncDisposable,
+    IDisposable,
+    IRouteBCredentialIdentity
+  {
+    public HemsController(IRouteBEchonetLiteHandlerFactory echonetLiteHandlerFactory, IRouteBCredentialProvider routeBCredentialProvider, ILoggerFactory? loggerFactory = null) {}
+    public HemsController(IServiceProvider serviceProvider) {}
+
+    protected EchonetClient Client { get; }
+    public EchonetObject Controller { get; }
+    [MemberNotNullWhen(false, "echonetLiteHandler")]
+    protected bool IsDisposed { [MemberNotNullWhen(false, "echonetLiteHandler")] get; }
+    public LowVoltageSmartElectricEnergyMeter SmartMeter { get; }
+    public TimeSpan TimeoutWaitingProactiveNotification { get; set; }
+    public TimeSpan TimeoutWaitingResponse1 { get; set; }
+    public TimeSpan TimeoutWaitingResponse2 { get; set; }
+
+    public ValueTask ConnectAsync(CancellationToken cancellationToken = default) {}
+    public async ValueTask DisconnectAsync(CancellationToken cancellationToken = default) {}
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    public async ValueTask DisposeAsync() {}
+    protected virtual async ValueTask DisposeAsyncCore() {}
+    [MemberNotNull("client")]
+    [MemberNotNull("Client")]
+    [MemberNotNull("smartMeterObject")]
+    [MemberNotNull("controllerObject")]
+    protected void ThrowIfDisconnected() {}
+  }
+
+  public sealed class LowVoltageSmartElectricEnergyMeter : DeviceSuperClass {
+    public IEchonetPropertyGetAccessor<int> Coefficient { get; }
+    public IEchonetPropertyGetAccessor<IReadOnlyList<(MeasurementValue<ElectricEnergyValue> NormalDirection, MeasurementValue<ElectricEnergyValue> ReverseDirection)>> CumulativeElectricEnergyLog2 { get; }
+    public IEchonetPropertySetGetAccessor<DateTime> DayForTheHistoricalDataOfCumulativeElectricEnergy1 { get; }
+    public IEchonetPropertySetGetAccessor<(DateTime DateAndTime, int NumberOfItems)> DayForTheHistoricalDataOfCumulativeElectricEnergy2 { get; }
+    public IEchonetPropertyGetAccessor<(ElectricCurrentValue RPhase, ElectricCurrentValue TPhase)> InstantaneousCurrent { get; }
+    public IEchonetPropertyGetAccessor<int> InstantaneousElectricPower { get; }
+    public IEchonetPropertyGetAccessor<ElectricEnergyValue> NormalDirectionCumulativeElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<MeasurementValue<ElectricEnergyValue>> NormalDirectionCumulativeElectricEnergyAtEvery30Min { get; }
+    public IEchonetPropertyGetAccessor<IReadOnlyList<MeasurementValue<ElectricEnergyValue>>> NormalDirectionCumulativeElectricEnergyLog1 { get; }
+    public IEchonetPropertyGetAccessor<int> NumberOfEffectiveDigitsCumulativeElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<(MeasurementValue<ElectricEnergyValue> NormalDirection, MeasurementValue<ElectricEnergyValue> ReverseDirection)> OneMinuteMeasuredCumulativeAmountsOfElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<ElectricEnergyValue> ReverseDirectionCumulativeElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<MeasurementValue<ElectricEnergyValue>> ReverseDirectionCumulativeElectricEnergyAtEvery30Min { get; }
+    public IEchonetPropertyGetAccessor<IReadOnlyList<MeasurementValue<ElectricEnergyValue>>> ReverseDirectionCumulativeElectricEnergyLog1 { get; }
+    public IEchonetPropertyGetAccessor<ReadOnlyMemory<byte>> RouteBIdentificationNumber { get; }
+    public IEchonetPropertyGetAccessor<decimal> UnitForCumulativeElectricEnergy { get; }
+  }
+
+  public static class MeasurementValue {
+    public static MeasurementValue<TValue> Create<TValue>(TValue @value, DateTime measuredAt) where TValue : struct {}
+  }
+
+  public sealed class RouteBDeviceFactory : IEchonetDeviceFactory {
+    public static RouteBDeviceFactory Instance { get; }
+
+    public RouteBDeviceFactory() {}
+
+    public EchonetDevice? Create(byte classGroupCode, byte classCode, byte instanceCode) {}
+  }
+
+  public readonly struct ElectricCurrentValue {
+    public decimal Amperes { get; }
+    public bool IsValid { get; }
+    public short RawValue { get; }
+
+    public override string ToString() {}
+  }
+
+  public readonly struct ElectricEnergyValue {
+    public static readonly ElectricEnergyValue NoMeasurementData; // = "(no data)"
+    public static readonly ElectricEnergyValue Zero; // = "0 [kWh]"
+
+    public bool IsValid { get; }
+    public decimal KiloWattHours { get; }
+    public int RawValue { get; }
+    public decimal WattHours { get; }
+
+    public override string ToString() {}
+    public bool TryGetValueAsKiloWattHours(out decimal @value) {}
+  }
+
+  public readonly struct MeasurementValue<TValue> where TValue : struct {
+    public MeasurementValue(TValue @value, DateTime measuredAt) {}
+
+    public DateTime MeasuredAt { get; }
+    public TValue Value { get; }
+
+    public void Deconstruct(out TValue @value, out DateTime measuredAt) {}
+    public override string ToString() {}
+  }
+}
 
 namespace Smdn.Net.EchonetLite.RouteB.Credentials {
-  public interface IRouteBCredential : IDisposable {
-    void WriteIdTo(IBufferWriter<byte> buffer);
-    void WritePasswordTo(IBufferWriter<byte> buffer);
-  }
-
-  public interface IRouteBCredentialIdentity {
-  }
-
-  public interface IRouteBCredentialProvider {
-    IRouteBCredential GetCredential(IRouteBCredentialIdentity identity);
-  }
-
   public static class RouteBCredentialServiceCollectionExtensions {
     public static IServiceCollection AddRouteBCredential(this IServiceCollection services, string id, string password) {}
     public static IServiceCollection AddRouteBCredentialFromEnvironmentVariable(this IServiceCollection services, string envVarForId, string envVarForPassword) {}
     public static IServiceCollection AddRouteBCredentialProvider(this IServiceCollection services, IRouteBCredentialProvider credentialProvider) {}
   }
-
-  public static class RouteBCredentials {
-    public const int AuthenticationIdLength = 32;
-    public const int PasswordLength = 12;
-  }
 }
 
 namespace Smdn.Net.EchonetLite.RouteB.Transport {
-  public interface IRouteBEchonetLiteHandlerBuilder {
-    IServiceCollection Services { get; }
-  }
-
-  public interface IRouteBEchonetLiteHandlerFactory {
-    ValueTask<RouteBEchonetLiteHandler> CreateAsync(CancellationToken cancellationToken);
-  }
-
-  public abstract class RouteBEchonetLiteHandler : EchonetLiteHandler {
-    protected RouteBEchonetLiteHandler() {}
-
-    public abstract IPAddress? PeerAddress { get; }
-
-    public ValueTask ConnectAsync(IRouteBCredential credential, CancellationToken cancellationToken = default) {}
-    protected abstract ValueTask ConnectAsyncCore(IRouteBCredential credential, CancellationToken cancellationToken);
-    public ValueTask DisconnectAsync(CancellationToken cancellationToken = default) {}
-    protected abstract ValueTask DisconnectAsyncCore(CancellationToken cancellationToken);
-  }
-
   public static class RouteBEchonetLiteHandlerBuilderServiceCollectionExtensions {
     public static IServiceCollection AddRouteBHandler(this IServiceCollection services, Action<IRouteBEchonetLiteHandlerBuilder> configure) {}
   }

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-netstandard2.1.apilist.cs
@@ -1,70 +1,128 @@
-// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview2)
+// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0-preview3)
 //   Name: Smdn.Net.EchonetLite.RouteB
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview2+c9161acca48757584c059440b4e2b704c3a80505
+//   InformationalVersion: 2.0.0-preview3+2612dc0eb7dba458048cbe65c5e156d272f8ee87
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
-//     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
+//     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Smdn.Net.EchonetLite, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.Primitives, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
 
 using System;
-using System.Buffers;
-using System.Net;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Smdn.Net.EchonetLite;
+using Smdn.Net.EchonetLite.ObjectModel;
+using Smdn.Net.EchonetLite.RouteB;
 using Smdn.Net.EchonetLite.RouteB.Credentials;
 using Smdn.Net.EchonetLite.RouteB.Transport;
-using Smdn.Net.EchonetLite.Transport;
+
+namespace Smdn.Net.EchonetLite.RouteB {
+  public class HemsController :
+    IAsyncDisposable,
+    IDisposable,
+    IRouteBCredentialIdentity
+  {
+    public HemsController(IRouteBEchonetLiteHandlerFactory echonetLiteHandlerFactory, IRouteBCredentialProvider routeBCredentialProvider, ILoggerFactory? loggerFactory = null) {}
+    public HemsController(IServiceProvider serviceProvider) {}
+
+    protected EchonetClient Client { get; }
+    public EchonetObject Controller { get; }
+    protected bool IsDisposed { get; }
+    public LowVoltageSmartElectricEnergyMeter SmartMeter { get; }
+    public TimeSpan TimeoutWaitingProactiveNotification { get; set; }
+    public TimeSpan TimeoutWaitingResponse1 { get; set; }
+    public TimeSpan TimeoutWaitingResponse2 { get; set; }
+
+    public ValueTask ConnectAsync(CancellationToken cancellationToken = default) {}
+    public async ValueTask DisconnectAsync(CancellationToken cancellationToken = default) {}
+    protected virtual void Dispose(bool disposing) {}
+    public void Dispose() {}
+    public async ValueTask DisposeAsync() {}
+    protected virtual async ValueTask DisposeAsyncCore() {}
+    protected void ThrowIfDisconnected() {}
+  }
+
+  public sealed class LowVoltageSmartElectricEnergyMeter : DeviceSuperClass {
+    public IEchonetPropertyGetAccessor<int> Coefficient { get; }
+    public IEchonetPropertyGetAccessor<IReadOnlyList<(MeasurementValue<ElectricEnergyValue> NormalDirection, MeasurementValue<ElectricEnergyValue> ReverseDirection)>> CumulativeElectricEnergyLog2 { get; }
+    public IEchonetPropertySetGetAccessor<DateTime> DayForTheHistoricalDataOfCumulativeElectricEnergy1 { get; }
+    public IEchonetPropertySetGetAccessor<(DateTime DateAndTime, int NumberOfItems)> DayForTheHistoricalDataOfCumulativeElectricEnergy2 { get; }
+    public IEchonetPropertyGetAccessor<(ElectricCurrentValue RPhase, ElectricCurrentValue TPhase)> InstantaneousCurrent { get; }
+    public IEchonetPropertyGetAccessor<int> InstantaneousElectricPower { get; }
+    public IEchonetPropertyGetAccessor<ElectricEnergyValue> NormalDirectionCumulativeElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<MeasurementValue<ElectricEnergyValue>> NormalDirectionCumulativeElectricEnergyAtEvery30Min { get; }
+    public IEchonetPropertyGetAccessor<IReadOnlyList<MeasurementValue<ElectricEnergyValue>>> NormalDirectionCumulativeElectricEnergyLog1 { get; }
+    public IEchonetPropertyGetAccessor<int> NumberOfEffectiveDigitsCumulativeElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<(MeasurementValue<ElectricEnergyValue> NormalDirection, MeasurementValue<ElectricEnergyValue> ReverseDirection)> OneMinuteMeasuredCumulativeAmountsOfElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<ElectricEnergyValue> ReverseDirectionCumulativeElectricEnergy { get; }
+    public IEchonetPropertyGetAccessor<MeasurementValue<ElectricEnergyValue>> ReverseDirectionCumulativeElectricEnergyAtEvery30Min { get; }
+    public IEchonetPropertyGetAccessor<IReadOnlyList<MeasurementValue<ElectricEnergyValue>>> ReverseDirectionCumulativeElectricEnergyLog1 { get; }
+    public IEchonetPropertyGetAccessor<ReadOnlyMemory<byte>> RouteBIdentificationNumber { get; }
+    public IEchonetPropertyGetAccessor<decimal> UnitForCumulativeElectricEnergy { get; }
+  }
+
+  public static class MeasurementValue {
+    public static MeasurementValue<TValue> Create<TValue>(TValue @value, DateTime measuredAt) where TValue : struct {}
+  }
+
+  public sealed class RouteBDeviceFactory : IEchonetDeviceFactory {
+    public static RouteBDeviceFactory Instance { get; }
+
+    public RouteBDeviceFactory() {}
+
+    public EchonetDevice? Create(byte classGroupCode, byte classCode, byte instanceCode) {}
+  }
+
+  public readonly struct ElectricCurrentValue {
+    public decimal Amperes { get; }
+    public bool IsValid { get; }
+    public short RawValue { get; }
+
+    public override string ToString() {}
+  }
+
+  public readonly struct ElectricEnergyValue {
+    public static readonly ElectricEnergyValue NoMeasurementData; // = "(no data)"
+    public static readonly ElectricEnergyValue Zero; // = "0 [kWh]"
+
+    public bool IsValid { get; }
+    public decimal KiloWattHours { get; }
+    public int RawValue { get; }
+    public decimal WattHours { get; }
+
+    public override string ToString() {}
+    public bool TryGetValueAsKiloWattHours(out decimal @value) {}
+  }
+
+  public readonly struct MeasurementValue<TValue> where TValue : struct {
+    public MeasurementValue(TValue @value, DateTime measuredAt) {}
+
+    public DateTime MeasuredAt { get; }
+    public TValue Value { get; }
+
+    public void Deconstruct(out TValue @value, out DateTime measuredAt) {}
+    public override string ToString() {}
+  }
+}
 
 namespace Smdn.Net.EchonetLite.RouteB.Credentials {
-  public interface IRouteBCredential : IDisposable {
-    void WriteIdTo(IBufferWriter<byte> buffer);
-    void WritePasswordTo(IBufferWriter<byte> buffer);
-  }
-
-  public interface IRouteBCredentialIdentity {
-  }
-
-  public interface IRouteBCredentialProvider {
-    IRouteBCredential GetCredential(IRouteBCredentialIdentity identity);
-  }
-
   public static class RouteBCredentialServiceCollectionExtensions {
     public static IServiceCollection AddRouteBCredential(this IServiceCollection services, string id, string password) {}
     public static IServiceCollection AddRouteBCredentialFromEnvironmentVariable(this IServiceCollection services, string envVarForId, string envVarForPassword) {}
     public static IServiceCollection AddRouteBCredentialProvider(this IServiceCollection services, IRouteBCredentialProvider credentialProvider) {}
   }
-
-  public static class RouteBCredentials {
-    public const int AuthenticationIdLength = 32;
-    public const int PasswordLength = 12;
-  }
 }
 
 namespace Smdn.Net.EchonetLite.RouteB.Transport {
-  public interface IRouteBEchonetLiteHandlerBuilder {
-    IServiceCollection Services { get; }
-  }
-
-  public interface IRouteBEchonetLiteHandlerFactory {
-    ValueTask<RouteBEchonetLiteHandler> CreateAsync(CancellationToken cancellationToken);
-  }
-
-  public abstract class RouteBEchonetLiteHandler : EchonetLiteHandler {
-    protected RouteBEchonetLiteHandler() {}
-
-    public abstract IPAddress? PeerAddress { get; }
-
-    public ValueTask ConnectAsync(IRouteBCredential credential, CancellationToken cancellationToken = default) {}
-    protected abstract ValueTask ConnectAsyncCore(IRouteBCredential credential, CancellationToken cancellationToken);
-    public ValueTask DisconnectAsync(CancellationToken cancellationToken = default) {}
-    protected abstract ValueTask DisconnectAsyncCore(CancellationToken cancellationToken);
-  }
-
   public static class RouteBEchonetLiteHandlerBuilderServiceCollectionExtensions {
     public static IServiceCollection AddRouteBHandler(this IServiceCollection services, Action<IRouteBEchonetLiteHandlerBuilder> configure) {}
   }


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #16](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/11367469971).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.RouteB-2.0.0-preview3`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite.RouteB-2.0.0-preview2`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite.RouteB-2.0.0-preview2`
- package_id: `Smdn.Net.EchonetLite.RouteB`
- package_id_with_version: `Smdn.Net.EchonetLite.RouteB-2.0.0-preview3`
- package_version: `2.0.0-preview3`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.RouteB-2.0.0-preview3-1729087927`
- release_tag: `releases/Smdn.Net.EchonetLite.RouteB-2.0.0-preview3`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/fcb87cce8274ffc358e1fd98a09f9336`](https://gist.github.com/smdn/fcb87cce8274ffc358e1fd98a09f9336)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.RouteB.2.0.0-preview3.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.EchonetLite.RouteB.latest.nuspec
+++ Smdn.Net.EchonetLite.RouteB.2.0.0-preview3.nuspec
@@ -1,33 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.EchonetLite.RouteB</id>
-    <version>2.0.0-preview2</version>
+    <version>2.0.0-preview3</version>
     <title>Smdn.Net.EchonetLite.RouteB</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.EchonetLite.RouteB.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</projectUrl>
-    <description>??????????????????????B????????ECHONET Lite????????????????`RouteBEchonetLiteHandler`????????????????????????????????????????`IRouteBCredential`???????</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB-2.0.0-preview2</releaseNotes>
-    <copyright>Copyright � 2024 smdn</copyright>
-    <tags>smdn.jp Route-B B-Route smart-meter smart-energy-meter ECHONET ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" branch="main" commit="c9161acca48757584c059440b4e2b704c3a80505" />
+    <description>Provides an application layer implementation for communication via the **route-B**, based on the specifications described in the "Interface Specifications for Application Layer Communication between Smart Electric Energy Meters and Controllers".  Provides APIs such as the `HemsController` class, which implements the "HEMS controller" in the specification, and the `LowVoltageSmartElectricEnergyMeter` class, which implements the "Requirements for low-voltage smart electric energy meter class".  「低圧スマート電力量メータ・HEMS コントローラ間アプリケーション通信インタフェース仕様書」に記載されている仕様に基づく、「Bルート」を介した通信を行うアプリケーション層の実装を提供します。  同仕様書における「HEMS コントローラ」に相当する`HemsController`クラス、「低圧スマート電力量メータクラス規定」を実装する`LowVoltageSmartElectricEnergyMeter`クラスなどのAPIを提供します。</description>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB-2.0.0-preview3</releaseNotes>
+    <copyright>Copyright © 2024 smdn</copyright>
+    <tags>smdn.jp Route-B B-Route smart-meter smart-energy-meter HEMS HEMS-controller LVSM ECHONET ECHONET-Lite</tags>
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" commit="2612dc0eb7dba458048cbe65c5e156d272f8ee87" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite.Transport" version="2.0.0-preview1" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite" version="2.0.0-preview2" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.0.0-preview1" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite.Transport" version="2.0.0-preview1" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite" version="2.0.0-preview2" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.0.0-preview1" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite.Transport" version="2.0.0-preview1" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite" version="2.0.0-preview2" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.0.0-preview1" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/net6.0/Smdn.Net.EchonetLite.RouteB.dll" target="lib/net6.0/Smdn.Net.EchonetLite.RouteB.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/net6.0/Smdn.Net.EchonetLite.RouteB.xml" target="lib/net6.0/Smdn.Net.EchonetLite.RouteB.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.dll" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.xml" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.dll" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.xml" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.Net.EchonetLite.RouteB.png" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

