### PR TITLE
Release main/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview3

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2)
+// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview3)
 //   Name: Smdn.Net.EchonetLite.RouteB.SkStackIP
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview2+4d034f0903ea62ea00625815ef039b64f3ec2917
+//   InformationalVersion: 2.0.0-preview3+370bdac018b42e5e04f531669d50f03b3bb6922f
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -9,8 +9,8 @@
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
-//     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.Primitives, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
 //     System.ComponentModel, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
@@ -29,6 +29,7 @@ using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Polly;
 using Smdn.Net.EchonetLite.RouteB.Credentials;
 using Smdn.Net.EchonetLite.RouteB.Transport;
 using Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP;
@@ -37,6 +38,7 @@ using Smdn.Net.SkStackIP;
 namespace Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP {
   public interface ISkStackRouteBEchonetLiteHandlerFactory : IRouteBEchonetLiteHandlerFactory {
     Action<SkStackRouteBSessionConfiguration>? ConfigureRouteBSessionConfiguration { get; set; }
+    Action<SkStackClient>? ConfigureSkStackClient { get; set; }
   }
 
   public enum SkStackRouteBTransportProtocol : int {
@@ -45,7 +47,9 @@ namespace Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP {
   }
 
   public abstract class SkStackRouteBEchonetLiteHandler : RouteBEchonetLiteHandler {
+    public static readonly string ResiliencePipelineKeyForAuthenticate = "SkStackRouteBEchonetLiteHandler.resiliencePipelineAuthenticate";
     public static readonly string ResiliencePipelineKeyForSend = "SkStackRouteBEchonetLiteHandler.resiliencePipelineSend";
+    public static readonly ResiliencePropertyKey<SkStackClient?> ResiliencePropertyKeyForClient; // = "ResiliencePropertyKeyForClient"
 
     public override IPAddress? LocalAddress { get; }
     public override IPAddress? PeerAddress { get; }
@@ -63,6 +67,7 @@ namespace Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP {
   }
 
   public static class SkStackRouteBEchonetLiteHandlerBuilderExtensions {
+    public static ISkStackRouteBEchonetLiteHandlerFactory ConfigureClient(this ISkStackRouteBEchonetLiteHandlerFactory factory, Action<SkStackClient> configureSkStackClient) {}
     public static ISkStackRouteBEchonetLiteHandlerFactory ConfigureSession(this ISkStackRouteBEchonetLiteHandlerFactory factory, Action<SkStackRouteBSessionConfiguration> configureRouteBSessionConfiguration) {}
   }
 
@@ -70,6 +75,7 @@ namespace Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP {
     protected SkStackRouteBEchonetLiteHandlerFactory(IServiceCollection services) {}
 
     public Action<SkStackRouteBSessionConfiguration>? ConfigureRouteBSessionConfiguration { get; set; }
+    public Action<SkStackClient>? ConfigureSkStackClient { get; set; }
     protected abstract SkStackRouteBTransportProtocol TransportProtocol { get; }
 
     public virtual async ValueTask<RouteBEchonetLiteHandler> CreateAsync(CancellationToken cancellationToken) {}

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2)
+// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview3)
 //   Name: Smdn.Net.EchonetLite.RouteB.SkStackIP
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview2+4d034f0903ea62ea00625815ef039b64f3ec2917
+//   InformationalVersion: 2.0.0-preview3+370bdac018b42e5e04f531669d50f03b3bb6922f
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -9,8 +9,8 @@
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
-//     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.EchonetLite.Transport, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.Primitives, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
@@ -29,6 +29,7 @@ using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Polly;
 using Smdn.Net.EchonetLite.RouteB.Credentials;
 using Smdn.Net.EchonetLite.RouteB.Transport;
 using Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP;
@@ -37,6 +38,7 @@ using Smdn.Net.SkStackIP;
 namespace Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP {
   public interface ISkStackRouteBEchonetLiteHandlerFactory : IRouteBEchonetLiteHandlerFactory {
     Action<SkStackRouteBSessionConfiguration>? ConfigureRouteBSessionConfiguration { get; set; }
+    Action<SkStackClient>? ConfigureSkStackClient { get; set; }
   }
 
   public enum SkStackRouteBTransportProtocol : int {
@@ -45,7 +47,9 @@ namespace Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP {
   }
 
   public abstract class SkStackRouteBEchonetLiteHandler : RouteBEchonetLiteHandler {
+    public static readonly string ResiliencePipelineKeyForAuthenticate = "SkStackRouteBEchonetLiteHandler.resiliencePipelineAuthenticate";
     public static readonly string ResiliencePipelineKeyForSend = "SkStackRouteBEchonetLiteHandler.resiliencePipelineSend";
+    public static readonly ResiliencePropertyKey<SkStackClient?> ResiliencePropertyKeyForClient; // = "ResiliencePropertyKeyForClient"
 
     public override IPAddress? LocalAddress { get; }
     public override IPAddress? PeerAddress { get; }
@@ -63,6 +67,7 @@ namespace Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP {
   }
 
   public static class SkStackRouteBEchonetLiteHandlerBuilderExtensions {
+    public static ISkStackRouteBEchonetLiteHandlerFactory ConfigureClient(this ISkStackRouteBEchonetLiteHandlerFactory factory, Action<SkStackClient> configureSkStackClient) {}
     public static ISkStackRouteBEchonetLiteHandlerFactory ConfigureSession(this ISkStackRouteBEchonetLiteHandlerFactory factory, Action<SkStackRouteBSessionConfiguration> configureRouteBSessionConfiguration) {}
   }
 
@@ -70,6 +75,7 @@ namespace Smdn.Net.EchonetLite.RouteB.Transport.SkStackIP {
     protected SkStackRouteBEchonetLiteHandlerFactory(IServiceCollection services) {}
 
     public Action<SkStackRouteBSessionConfiguration>? ConfigureRouteBSessionConfiguration { get; set; }
+    public Action<SkStackClient>? ConfigureSkStackClient { get; set; }
     protected abstract SkStackRouteBTransportProtocol TransportProtocol { get; }
 
     public virtual async ValueTask<RouteBEchonetLiteHandler> CreateAsync(CancellationToken cancellationToken) {}


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #17](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/11367616597).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview3`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2`
- package_id: `Smdn.Net.EchonetLite.RouteB.SkStackIP`
- package_id_with_version: `Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview3`
- package_version: `2.0.0-preview3`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview3-1729088392`
- release_tag: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview3`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/ff4e1cfadc08203b8eea75ad63b1cef2`](https://gist.github.com/smdn/ff4e1cfadc08203b8eea75ad63b1cef2)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.RouteB.SkStackIP.2.0.0-preview3.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.EchonetLite.RouteB.SkStackIP.latest.nuspec
+++ Smdn.Net.EchonetLite.RouteB.SkStackIP.2.0.0-preview3.nuspec
@@ -1,36 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.EchonetLite.RouteB.SkStackIP</id>
-    <version>2.0.0-preview2</version>
+    <version>2.0.0-preview3</version>
     <title>Smdn.Net.EchonetLite.RouteB.SkStackIP</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.EchonetLite.RouteB.SkStackIP.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</projectUrl>
-    <description>Skyley Networks?[SKSTACK IP](https://www.skyley.com/wiki/?SKSTACK+IP+for+HAN)?????? ??????????????????????B????????ECHONET Lite???????????API??????? ECHONET Lite?????????????????????`SkStackRouteBUdpEchonetLiteHandler`??????????API???????</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview2</releaseNotes>
-    <copyright>Copyright � 2024 smdn</copyright>
+    <description>Skyley Networksの[SKSTACK IP](https://www.skyley.com/wiki/?SKSTACK+IP+for+HAN)を使用して、 スマート電力量メータとの情報伝達手段である「Bルート」を介したECHONET Lite規格の通信を扱うためのAPIを提供します。 ECHONET Lite規格における下位通信層に相当する実装である`SkStackRouteBUdpEchonetLiteHandler`クラスをはじめとするAPIを提供します。</description>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0-preview3</releaseNotes>
+    <copyright>Copyright © 2024 smdn</copyright>
     <tags>smdn.jp SKSTACK SKSTACK-IP Route-B B-Route smart-meter smart-energy-meter ECHONET ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" branch="main" commit="4d034f0903ea62ea00625815ef039b64f3ec2917" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" commit="370bdac018b42e5e04f531669d50f03b3bb6922f" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite.RouteB" version="2.0.0-preview2" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.0.0-preview1" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.SkStackIP" version="[1.2.0, 2.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite.RouteB" version="2.0.0-preview2" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.0.0-preview1" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.SkStackIP" version="[1.2.0, 2.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite.RouteB" version="2.0.0-preview2" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.0.0-preview1" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.SkStackIP" version="[1.2.0, 2.0.0)" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/net6.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.dll" target="lib/net6.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/net6.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.xml" target="lib/net6.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.dll" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.xml" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.SkStackIP.dll" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.SkStackIP.xml" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.Net.EchonetLite.RouteB.SkStackIP.png" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

