### PR TITLE
Release main/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview4

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net6.0.apilist.cs
@@ -1,13 +1,13 @@
-// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3)
+// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview4)
 //   Name: Smdn.Net.EchonetLite.RouteB.BP35XX
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview3+f083b2de6dc07603893bff9d4a263609fd1a919e
+//   InformationalVersion: 2.0.0-preview4+c7a206f316403313ee223391269df5de9d965d32
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.Devices.BP35XX, Version=1.0.0.0, Culture=neutral
-//     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.RouteB.SkStackIP, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
 //     System.ComponentModel, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-net8.0.apilist.cs
@@ -1,13 +1,13 @@
-// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3)
+// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview4)
 //   Name: Smdn.Net.EchonetLite.RouteB.BP35XX
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview3+f083b2de6dc07603893bff9d4a263609fd1a919e
+//   InformationalVersion: 2.0.0-preview4+c7a206f316403313ee223391269df5de9d965d32
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.Devices.BP35XX, Version=1.0.0.0, Culture=neutral
-//     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.RouteB.SkStackIP, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.BP35XX/Smdn.Net.EchonetLite.RouteB.BP35XX-netstandard2.1.apilist.cs
@@ -1,13 +1,13 @@
-// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3)
+// Smdn.Net.EchonetLite.RouteB.BP35XX.dll (Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview4)
 //   Name: Smdn.Net.EchonetLite.RouteB.BP35XX
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview3+f083b2de6dc07603893bff9d4a263609fd1a919e
+//   InformationalVersion: 2.0.0-preview4+c7a206f316403313ee223391269df5de9d965d32
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.Devices.BP35XX, Version=1.0.0.0, Culture=neutral
-//     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.RouteB.SkStackIP, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #18](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/11367830632).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview4`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3`
- package_id: `Smdn.Net.EchonetLite.RouteB.BP35XX`
- package_id_with_version: `Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview4`
- package_version: `2.0.0-preview4`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview4-1729089059`
- release_tag: `releases/Smdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview4`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/7c73575795269382317a1c5f37e638d8`](https://gist.github.com/smdn/7c73575795269382317a1c5f37e638d8)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.RouteB.BP35XX.2.0.0-preview4.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.EchonetLite.RouteB.BP35XX.latest.nuspec
+++ Smdn.Net.EchonetLite.RouteB.BP35XX.2.0.0-preview4.nuspec
@@ -1,33 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.EchonetLite.RouteB.BP35XX</id>
-    <version>2.0.0-preview3</version>
+    <version>2.0.0-preview4</version>
     <title>Smdn.Net.EchonetLite.RouteB.BP35XX</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.EchonetLite.RouteB.BP35XX.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</projectUrl>
-    <description>BP35A1???Skyley Networks?[SKSTACK IP](https://www.skyley.com/wiki/?SKSTACK+IP+for+HAN)?????[ROHM Wi-SUN?????](https://www.rohm.co.jp/products/wireless-communication/specified-low-power-radio-modules)????????????????????????????B????????ECHONET Lite???????????API??????? ECHONET Lite???????????????????????????????`BP35A1RouteBEchonetLiteHandlerFactory`???????API???????</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview3</releaseNotes>
-    <copyright>Copyright � 2024 smdn</copyright>
+    <description>BP35A1など、Skyley Networksの[SKSTACK IP](https://www.skyley.com/wiki/?SKSTACK+IP+for+HAN)を搭載する[ROHM Wi-SUNモジュール](https://www.rohm.co.jp/products/wireless-communication/specified-low-power-radio-modules)を使用して、スマート電力量メータとの情報伝達手段である「Bルート」を介したECHONET Lite規格の通信を扱うためのAPIを提供します。 ECHONET Lite規格における下位通信層に相当する実装を作成するファクトリクラス`BP35A1RouteBEchonetLiteHandlerFactory`をはじめとするAPIを提供します。</description>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB.BP35XX-2.0.0-preview4</releaseNotes>
+    <copyright>Copyright © 2024 smdn</copyright>
     <tags>smdn.jp SKSTACK SKSTACK-IP Route-B B-Route Wi-SUN BP35A1 ROHM-BP35A1 ECHONET ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" branch="main" commit="f083b2de6dc07603893bff9d4a263609fd1a919e" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" commit="c7a206f316403313ee223391269df5de9d965d32" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Smdn.Devices.BP35XX" version="[1.0.0, 3.0.0)" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite.RouteB.SkStackIP" version="2.0.0-preview2" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite.RouteB.SkStackIP" version="2.0.0-preview3" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Smdn.Devices.BP35XX" version="[1.0.0, 3.0.0)" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite.RouteB.SkStackIP" version="2.0.0-preview2" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite.RouteB.SkStackIP" version="2.0.0-preview3" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Smdn.Devices.BP35XX" version="[1.0.0, 3.0.0)" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite.RouteB.SkStackIP" version="2.0.0-preview2" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite.RouteB.SkStackIP" version="2.0.0-preview3" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/net6.0/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" target="lib/net6.0/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/net6.0/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" target="lib/net6.0/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.BP35XX.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.BP35XX.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.Net.EchonetLite.RouteB.BP35XX.png" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.BP35XX/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

