### PR TITLE
プロパティ値の更新を検知できるようにする

### DIFF
--- a/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.AIF.cs
+++ b/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.AIF.cs
@@ -481,7 +481,9 @@ partial class HemsController {
           }
 
           try {
-            using var ctr = cancellationToken.Register(() => _ = tcs.TrySetCanceled(ctsTimeoutOrCancellationRequest.Token));
+            using var ctr = ctsTimeoutOrCancellationRequest.Token.Register(
+              () => _ = tcs.TrySetCanceled(ctsTimeoutOrCancellationRequest.Token)
+            );
 
             client.InstanceListUpdated += HandleInstanceListUpdated;
 
@@ -617,7 +619,7 @@ partial class HemsController {
         _ = await client.AcquirePropertyMapsAsync(
           device: smartMeterObject,
           extraPropertyCodes: [smartMeterObject.Protocol.PropertyCode],
-          cancellationToken: cancellationToken
+          cancellationToken: ctsTimeoutOrCancellationRequest.Token
         ).ConfigureAwait(false);
 #pragma warning restore CS8602, CS8604
 

--- a/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.AIF.cs
+++ b/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.AIF.cs
@@ -267,6 +267,9 @@ partial class HemsController {
         loggerFactoryForEchonetClient
       );
 
+      // share same ISynchronizeInvoke
+      client.SynchronizingObject = synchronizingObject;
+
       Logger?.LogInformation("Finding smart meter node and device object (this may take a few seconds) ...");
 
       using (var scope = Logger?.BeginScope("Finding smart meter")) {

--- a/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.cs
+++ b/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.cs
@@ -140,7 +140,7 @@ public partial class HemsController : IRouteBCredentialIdentity, IDisposable, IA
 #if SYSTEM_DIAGNOSTICS_CODEANALYSIS_MEMBERNOTNULLATTRIBUTE
   [MemberNotNull(nameof(echonetLiteHandler))]
 #endif
-  private void ThrowIfDisposed()
+  protected void ThrowIfDisposed()
   {
 #pragma warning disable CA1513
     if (IsDisposed)

--- a/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.cs
+++ b/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
 using System;
+using System.ComponentModel;
 #if SYSTEM_DIAGNOSTICS_CODEANALYSIS_MEMBERNOTNULLATTRIBUTE || SYSTEM_DIAGNOSTICS_CODEANALYSIS_MEMBERNOTNULLWHENATTRIBUTE
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -36,6 +37,28 @@ public partial class HemsController : IRouteBCredentialIdentity, IDisposable, IA
   private readonly IRouteBCredentialProvider credentialProvider;
   private readonly ILoggerFactory? loggerFactoryForEchonetClient;
   private RouteBEchonetLiteHandler? echonetLiteHandler;
+
+  private ISynchronizeInvoke? synchronizingObject;
+
+  /// <summary>
+  /// イベントの結果として発行されるイベントハンドラー呼び出しをマーシャリングするために使用する<see cref="ISynchronizeInvoke"/>オブジェクトを取得または設定します。
+  /// </summary>
+  public ISynchronizeInvoke? SynchronizingObject {
+    get {
+      ThrowIfDisposed();
+
+      return synchronizingObject;
+    }
+    set {
+      ThrowIfDisposed();
+
+      synchronizingObject = value;
+
+      // share same ISynchronizeInvoke
+      if (client is not null)
+        client.SynchronizingObject = value;
+    }
+  }
 
   protected ILogger? Logger { get; }
 

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertySetGetAccessor.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/EchonetPropertySetGetAccessor.cs
@@ -27,7 +27,7 @@ internal sealed class EchonetPropertySetGetAccessor<TValue> :
 
       BaseProperty.WriteValue(
         writer => formatValue(writer, value),
-        raiseValueChangedEvent: false,
+        raiseValueUpdatedEvent: false,
         setLastUpdatedTime: false
       );
     }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/IEchonetPropertyAccessorExtensions.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite.ObjectModel/IEchonetPropertyAccessorExtensions.cs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Net.EchonetLite.ObjectModel;
+
+/// <summary>
+/// <see cref="IEchonetPropertyAccessor"/>に対して拡張メソッドを追加するクラスです。
+/// </summary>
+/// <seealso cref="IEchonetPropertyAccessor"/>
+public static class IEchonetPropertyAccessorExtensions {
+  /// <summary>
+  /// <see cref="IEchonetPropertyGetAccessor{TValue}"/>とバインドされている<see cref="EchonetProperty"/>が
+  /// 何らかの値を持っているかどうかを表す値を取得します。
+  /// </summary>
+  /// <typeparam name="TValue"><see cref="IEchonetPropertyGetAccessor{TValue}"/>が表すECHONET プロパティの値の型。</typeparam>
+  /// <param name="getAccessor">対象の<see cref="IEchonetPropertyGetAccessor{TValue}"/>。</param>
+  /// <returns>
+  /// <paramref name="getAccessor"/>とバインドされている<see cref="EchonetProperty"/>の<see cref="EchonetProperty.ValueSpan"/>が空でない場合は、<see langword="true"/>。
+  /// 空の場合は、<see langword="false"/>。
+  /// </returns>
+  /// <exception cref="ArgumentNullException"><paramref name="getAccessor"/>を<see langword="null"/>にすることはできません。</exception>
+  public static bool HasValue<TValue>(
+    this IEchonetPropertyGetAccessor<TValue> getAccessor
+  )
+  {
+    if (getAccessor is null)
+      throw new ArgumentNullException(nameof(getAccessor));
+
+    return !getAccessor.BaseProperty.ValueSpan.IsEmpty;
+  }
+
+  /// <summary>
+  /// <see cref="IEchonetPropertyGetAccessor{TValue}"/>とバインドされている<see cref="EchonetProperty"/>に対して
+  /// 最後に値を設定した日時から一定時間経過しているかどうかを表す値を取得します。
+  /// </summary>
+  /// <typeparam name="TValue"><see cref="IEchonetPropertyGetAccessor{TValue}"/>が表すECHONET プロパティの値の型。</typeparam>
+  /// <param name="getAccessor">対象の<see cref="IEchonetPropertyGetAccessor{TValue}"/>。</param>
+  /// <param name="duration">現在日時に対してどの程度経過しているかの時間間隔を指定する<see cref="TimeSpan"/>。</param>
+  /// <returns>
+  /// <paramref name="getAccessor"/>とバインドされている<see cref="EchonetProperty"/>の<see cref="EchonetProperty.LastUpdatedTime"/>の値が、
+  /// 現在日時から<paramref name="duration"/>よりも経過している場合は<see langword="true"/>、そうでなければ<see langword="false"/>。
+  /// </returns>
+  /// <exception cref="ArgumentNullException"><paramref name="getAccessor"/>を<see langword="null"/>にすることはできません。</exception>
+  public static bool HasElapsedSinceLastUpdated<TValue>(
+    this IEchonetPropertyGetAccessor<TValue> getAccessor,
+    TimeSpan duration
+  )
+  {
+    if (getAccessor is null)
+      throw new ArgumentNullException(nameof(getAccessor));
+
+    // XXX: consider to support using TimeProvider
+    return getAccessor.BaseProperty.LastUpdatedTime + duration < DateTime.Now;
+  }
+
+  /// <summary>
+  /// <see cref="IEchonetPropertyGetAccessor{TValue}"/>とバインドされている<see cref="EchonetProperty"/>に対して
+  /// 最後に値を設定した日時が指定した日時を経過しているかどうかを表す値を取得します。
+  /// </summary>
+  /// <typeparam name="TValue"><see cref="IEchonetPropertyGetAccessor{TValue}"/>が表すECHONET プロパティの値の型。</typeparam>
+  /// <param name="getAccessor">対象の<see cref="IEchonetPropertyGetAccessor{TValue}"/>。</param>
+  /// <param name="dateTime">経過しているかどうか判断する比較対象の日時を表す<see cref="DateTime"/>。</param>
+  /// <returns>
+  /// <paramref name="getAccessor"/>とバインドされている<see cref="EchonetProperty"/>の<see cref="EchonetProperty.LastUpdatedTime"/>の値が、
+  /// <paramref name="dateTime"/>よりも前である場合は<see langword="true"/>、そうでなければ<see langword="false"/>。
+  /// </returns>
+  /// <exception cref="ArgumentNullException"><paramref name="getAccessor"/>を<see langword="null"/>にすることはできません。</exception>
+  public static bool HasElapsedSinceLastUpdated<TValue>(
+    this IEchonetPropertyGetAccessor<TValue> getAccessor,
+    DateTime dateTime
+  )
+  {
+    if (getAccessor is null)
+      throw new ArgumentNullException(nameof(getAccessor));
+
+    return getAccessor.BaseProperty.LastUpdatedTime < dateTime;
+  }
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
@@ -61,7 +61,7 @@ partial class EchonetClient
 
       property.SetValue(
         newValue: bufferMemory,
-        raiseValueChangedEvent: false,
+        raiseValueUpdatedEvent: false,
         setLastUpdatedTime: true
       );
     }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
@@ -119,7 +119,7 @@ partial class EchonetClient
     // インスタンスリスト受信後に発生するイベントをハンドリングする
     void HandleInstanceListUpdated(object? sender, EchonetNode node)
     {
-      logger?.LogDebug("HandleInstanceListUpdated");
+      Logger?.LogDebug("HandleInstanceListUpdated");
 
       // この時点で条件がtrueとなったら、結果を確定する
       if (onInstanceListUpdated(node, state))
@@ -220,7 +220,7 @@ partial class EchonetClient
     if (device.Node is not EchonetOtherNode otherNode)
       throw new InvalidOperationException("Cannot acquire property maps of self node.");
 
-    using var scope = logger?.BeginScope("Acquiring property maps");
+    using var scope = Logger?.BeginScope("Acquiring property maps");
 
     OnPropertyMapAcquiring(device);
 
@@ -235,7 +235,7 @@ partial class EchonetClient
 
     // 不可応答は無視
     if (!result.IsSuccess) {
-      logger?.LogWarning("Service not available (Node: {NodeAddress}, EOJ: {EOJ})", otherNode.Address, device.EOJ);
+      Logger?.LogWarning("Service not available (Node: {NodeAddress}, EOJ: {EOJ})", otherNode.Address, device.EOJ);
       return false;
     }
 
@@ -279,10 +279,10 @@ partial class EchonetClient
       )
     );
 
-    logger?.LogDebug("Acquired (Node: {NodeAddress}, EOJ: {EOJ})", otherNode.Address, device.EOJ);
+    Logger?.LogDebug("Acquired (Node: {NodeAddress}, EOJ: {EOJ})", otherNode.Address, device.EOJ);
 
     foreach (var (_, p) in device.Properties.OrderBy(static pair => pair.Key)) {
-      logger?.LogDebug(
+      Logger?.LogDebug(
         "Node: {NodeAddress} EOJ: {EOJ}, EPC: {EPC:X2}, Access Rule: {CanSet}/{CanGet}/{CanAnnounceStatusChange}",
         otherNode.Address,
         device.EOJ,

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Operations.cs
@@ -279,18 +279,31 @@ partial class EchonetClient
       )
     );
 
-    Logger?.LogDebug("Acquired (Node: {NodeAddress}, EOJ: {EOJ})", otherNode.Address, device.EOJ);
+    Logger?.LogInformation(
+      "Acquired (Node: {NodeAddress}, EOJ: {EOJ}, Properties: {Properties})",
+      otherNode.Address,
+      device.EOJ,
+      string.Join(
+        ", ",
+        device
+          .Properties
+          .OrderBy(static pair => pair.Key)
+          .Select(static pair => pair.Key.ToString("X2", provider: null))
+      )
+    );
 
-    foreach (var (_, p) in device.Properties.OrderBy(static pair => pair.Key)) {
-      Logger?.LogDebug(
-        "Node: {NodeAddress} EOJ: {EOJ}, EPC: {EPC:X2}, Access Rule: {CanSet}/{CanGet}/{CanAnnounceStatusChange}",
-        otherNode.Address,
-        device.EOJ,
-        p.Code,
-        p.CanSet ? "SET" : "---",
-        p.CanGet ? "GET" : "---",
-        p.CanAnnounceStatusChange ? "ANNO" : "----"
-      );
+    if (Logger is not null && Logger.IsEnabled(LogLevel.Debug)) {
+      foreach (var (_, p) in device.Properties.OrderBy(static pair => pair.Key)) {
+        Logger.LogDebug(
+          "Node: {NodeAddress} EOJ: {EOJ}, EPC: {EPC:X2}, Access Rule: {CanSet}/{CanGet}/{CanAnnounceStatusChange}",
+          otherNode.Address,
+          device.EOJ,
+          p.Code,
+          p.CanSet ? "SET" : "---",
+          p.CanGet ? "GET" : "---",
+          p.CanAnnounceStatusChange ? "ANNO" : "----"
+        );
+      }
     }
 
     device.HasPropertyMapAcquired = true;

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
@@ -114,8 +114,8 @@ partial class EchonetClient
             _ = await HandleWriteOneWayAsync(address, tid, message, destObject).ConfigureAwait(false);
           }
           catch (Exception ex) {
-            if (logger is not null)
-              LogExceptionAtFormat1MessageHandler(logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+            if (Logger is not null)
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
 
             throw;
           }
@@ -130,8 +130,8 @@ partial class EchonetClient
             _ = await HandleWriteAsync(address, tid, message, destObject).ConfigureAwait(false);
           }
           catch (Exception ex) {
-            if (logger is not null)
-              LogExceptionAtFormat1MessageHandler(logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+            if (Logger is not null)
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
 
             throw;
           }
@@ -146,8 +146,8 @@ partial class EchonetClient
             _ = await HandleReadAsync(address, tid, message, destObject).ConfigureAwait(false);
           }
           catch (Exception ex) {
-            if (logger is not null)
-              LogExceptionAtFormat1MessageHandler(logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+            if (Logger is not null)
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
 
             throw;
           }
@@ -167,8 +167,8 @@ partial class EchonetClient
             _ = await HandleWriteReadAsync(address, tid, message, destObject).ConfigureAwait(false);
           }
           catch (Exception ex) {
-            if (logger is not null)
-              LogExceptionAtFormat1MessageHandler(logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+            if (Logger is not null)
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
 
             throw;
           }
@@ -184,8 +184,8 @@ partial class EchonetClient
             _ = HandleNotifyOneWay(address, tid, message, sourceNode);
           }
           catch (Exception ex) {
-            if (logger is not null)
-              LogExceptionAtFormat1MessageHandler(logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+            if (Logger is not null)
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
 
             throw;
           }
@@ -199,8 +199,8 @@ partial class EchonetClient
             _ = await HandleNotifyAsync(address, tid, message, sourceNode, destObject).ConfigureAwait(false);
           }
           catch (Exception ex) {
-            if (logger is not null)
-              LogExceptionAtFormat1MessageHandler(logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+            if (Logger is not null)
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
 
             throw;
           }
@@ -241,8 +241,8 @@ partial class EchonetClient
     // ハンドリングを行うタスクがなく、進行中のトランザクションにも該当しない場合
     if (handlerTask is null && !TryFindTransaction(tid, out _)) {
       // 要求には対応しないが、ログに記録する
-      if (logger is not null)
-        LogUnmanagedTransactionAtFormat1MessageHandler(logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, null);
+      if (Logger is not null)
+        LogUnmanagedTransactionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, null);
     }
   }
 #pragma warning restore CA1502
@@ -280,8 +280,8 @@ partial class EchonetClient
 
     const ESV RequestServiceCode = ESV.SetI;
 
-    if (logger is not null)
-      LogHandlingServiceResponse(logger, RequestServiceCode, address, tid);
+    if (Logger is not null)
+      LogHandlingServiceResponse(Logger, RequestServiceCode, address, tid);
 
     var hasError = false;
     var requestProps = message.GetProperties();
@@ -372,8 +372,8 @@ partial class EchonetClient
   {
     const ESV RequestServiceCode = ESV.SetC;
 
-    if (logger is not null)
-      LogHandlingServiceResponse(logger, RequestServiceCode, address, tid);
+    if (Logger is not null)
+      LogHandlingServiceResponse(Logger, RequestServiceCode, address, tid);
 
     var hasError = false;
     var requestProps = message.GetProperties();
@@ -469,8 +469,8 @@ partial class EchonetClient
   {
     const ESV RequestServiceCode = ESV.Get;
 
-    if (logger is not null)
-      LogHandlingServiceResponse(logger, RequestServiceCode, address, tid);
+    if (Logger is not null)
+      LogHandlingServiceResponse(Logger, RequestServiceCode, address, tid);
 
     var hasError = false;
     var requestProps = message.GetProperties();
@@ -563,8 +563,8 @@ partial class EchonetClient
   {
     const ESV RequestServiceCode = ESV.SetGet;
 
-    if (logger is not null)
-      LogHandlingServiceResponse(logger, RequestServiceCode, address, tid);
+    if (Logger is not null)
+      LogHandlingServiceResponse(Logger, RequestServiceCode, address, tid);
 
     var hasError = false;
     var (requestPropsForSet, requestPropsForGet) = message.GetPropertiesForSetAndGet();
@@ -681,8 +681,8 @@ partial class EchonetClient
   {
     const ESV RequestServiceCode = ESV.InfRequest;
 
-    if (logger is not null)
-      LogHandlingServiceResponse(logger, RequestServiceCode, address, tid);
+    if (Logger is not null)
+      LogHandlingServiceResponse(Logger, RequestServiceCode, address, tid);
 
     var hasError = false;
     var objectAdded = false;
@@ -692,7 +692,7 @@ partial class EchonetClient
       : sourceNode.GetOrAddDevice(deviceFactory, message.SEOJ, out objectAdded); // 未知のオブジェクト(プロパティはない状態で新規作成)
 
     if (objectAdded) {
-      logger?.LogInformation(
+      Logger?.LogInformation(
         "New object added (Node: {NodeAddress}, EOJ: {EOJ})",
         sourceNode.Address,
         sourceObject.EOJ
@@ -751,8 +751,8 @@ partial class EchonetClient
   {
     const ESV RequestServiceCode = ESV.InfC;
 
-    if (logger is not null)
-      LogHandlingServiceResponse(logger, RequestServiceCode, address, tid);
+    if (Logger is not null)
+      LogHandlingServiceResponse(Logger, RequestServiceCode, address, tid);
 
     var hasError = false;
     var requestProps = message.GetProperties();
@@ -770,7 +770,7 @@ partial class EchonetClient
       : sourceNode.GetOrAddDevice(deviceFactory, message.SEOJ, out objectAdded); // 未知のオブジェクト(プロパティはない状態で新規作成)
 
     if (objectAdded) {
-      logger?.LogInformation(
+      Logger?.LogInformation(
         "New object added (Node: {NodeAddress}, EOJ: {EOJ})",
         sourceNode.Address,
         sourceObject.EOJ
@@ -846,10 +846,10 @@ partial class EchonetClient
     ReadOnlyMemory<byte> edtInstantListNotification
   )
   {
-    using var scope = logger?.BeginScope($"Instance list (Node: {sourceNode.Address})");
+    using var scope = Logger?.BeginScope($"Instance list (Node: {sourceNode.Address})");
 
     if (!PropertyContentSerializer.TryDeserializeInstanceListNotification(edtInstantListNotification.Span, out var instanceList)) {
-      logger?.LogWarning(
+      Logger?.LogWarning(
         "Invalid instance list received (EDT: {EDT})",
         edtInstantListNotification.ToHexString()
       );
@@ -857,7 +857,7 @@ partial class EchonetClient
       return false;
     }
 
-    logger?.LogDebug("Updating");
+    Logger?.LogDebug("Updating");
 
     OnInstanceListUpdating(sourceNode);
 
@@ -865,7 +865,7 @@ partial class EchonetClient
       _ = sourceNode.GetOrAddDevice(deviceFactory, eoj, out var added);
 
       if (added) {
-        logger?.LogInformation(
+        Logger?.LogInformation(
           "New object (Node: {NodeAddress}, EOJ: {EOJ})",
           sourceNode.Address,
           eoj
@@ -875,7 +875,7 @@ partial class EchonetClient
 
     OnInstanceListUpdated(sourceNode);
 
-    logger?.LogDebug("Updated");
+    Logger?.LogDebug("Updated");
 
     return true;
   }

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceHandlings.cs
@@ -24,18 +24,18 @@ partial class EchonetClient
   [CLSCompliant(false)]
   public static readonly ResiliencePropertyKey<ESV> ResiliencePropertyKeyForResponseServiceCode = new(nameof(ResiliencePropertyKeyForResponseServiceCode));
 
-  private static readonly Action<ILogger, IPAddress, ushort, ESV, EOJ, EOJ, Exception?>
-  LogExceptionAtFormat1MessageHandler = LoggerMessage.Define<IPAddress, ushort, ESV, EOJ, EOJ>(
+  private static readonly Action<ILogger, IPAddress, ushort, Format1Message, Exception?>
+  LogExceptionAtFormat1MessageHandler = LoggerMessage.Define<IPAddress, ushort, Format1Message>(
     LogLevel.Error,
     eventId: default, // TODO
-    formatString: "An error occured while handling received message (Address: {Address}, TID: {TID:X4}, ESV: {ESV}, SEOJ: {SEOJ}, DEOJ: {DEOJ})"
+    formatString: "An error occured while handling received message (Address: {Address}, TID: {TID:X4}, Message: {Message})"
   );
 
-  private static readonly Action<ILogger, IPAddress, ushort, ESV, EOJ, EOJ, Exception?>
-  LogUnmanagedTransactionAtFormat1MessageHandler = LoggerMessage.Define<IPAddress, ushort, ESV, EOJ, EOJ>(
+  private static readonly Action<ILogger, IPAddress, ushort, Format1Message, Exception?>
+  LogUnmanagedTransactionAtFormat1MessageHandler = LoggerMessage.Define<IPAddress, ushort, Format1Message>(
     LogLevel.Warning,
     eventId: default, // TODO
-    formatString: "An unmanaged transaction (Address: {Address}, TID: {TID:X4}, ESV: {ESV}, SEOJ: {SEOJ}, DEOJ: {DEOJ})"
+    formatString: "An unmanaged transaction (Address: {Address}, TID: {TID:X4}, Message: {Message})"
   );
 
   [Obsolete("call LogHandlingServiceResponse")]
@@ -115,7 +115,7 @@ partial class EchonetClient
           }
           catch (Exception ex) {
             if (Logger is not null)
-              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message, ex);
 
             throw;
           }
@@ -131,7 +131,7 @@ partial class EchonetClient
           }
           catch (Exception ex) {
             if (Logger is not null)
-              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message, ex);
 
             throw;
           }
@@ -147,7 +147,7 @@ partial class EchonetClient
           }
           catch (Exception ex) {
             if (Logger is not null)
-              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message, ex);
 
             throw;
           }
@@ -168,7 +168,7 @@ partial class EchonetClient
           }
           catch (Exception ex) {
             if (Logger is not null)
-              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message, ex);
 
             throw;
           }
@@ -185,7 +185,7 @@ partial class EchonetClient
           }
           catch (Exception ex) {
             if (Logger is not null)
-              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message, ex);
 
             throw;
           }
@@ -200,7 +200,7 @@ partial class EchonetClient
           }
           catch (Exception ex) {
             if (Logger is not null)
-              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, ex);
+              LogExceptionAtFormat1MessageHandler(Logger, address, tid, message, ex);
 
             throw;
           }
@@ -242,7 +242,7 @@ partial class EchonetClient
     if (handlerTask is null && !TryFindTransaction(tid, out _)) {
       // 要求には対応しないが、ログに記録する
       if (Logger is not null)
-        LogUnmanagedTransactionAtFormat1MessageHandler(Logger, address, tid, message.ESV, message.SEOJ, message.DEOJ, null);
+        LogUnmanagedTransactionAtFormat1MessageHandler(Logger, address, tid, message, null);
     }
   }
 #pragma warning restore CA1502

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.ServiceRequests.cs
@@ -158,7 +158,7 @@ partial class EchonetClient
       if (value.Message.ESV != ESV.SetIServiceNotAvailable)
         return;
 
-      logger?.LogDebug(
+      Logger?.LogDebug(
         "Handling {ESV} (From: {Address}, TID: {TID:X4})",
         value.Message.ESV.ToSymbolString(),
         value.Address,
@@ -278,7 +278,7 @@ partial class EchonetClient
       if (!(value.Message.ESV == ESV.SetResponse || value.Message.ESV == ESV.SetCServiceNotAvailable))
         return;
 
-      logger?.LogDebug(
+      Logger?.LogDebug(
         "Handling {ESV} (From: {Address}, TID: {TID:X4})",
         value.Message.ESV.ToSymbolString(),
         value.Address,
@@ -404,7 +404,7 @@ partial class EchonetClient
       if (!(value.Message.ESV == ESV.GetResponse || value.Message.ESV == ESV.GetServiceNotAvailable))
         return;
 
-      logger?.LogDebug(
+      Logger?.LogDebug(
         "Handling {ESV} (From: {Address}, TID: {TID:X4})",
         value.Message.ESV.ToSymbolString(),
         value.Address,
@@ -538,7 +538,7 @@ partial class EchonetClient
       if (!(value.Message.ESV == ESV.SetGetResponse || value.Message.ESV == ESV.SetGetServiceNotAvailable))
         return;
 
-      logger?.LogDebug(
+      Logger?.LogDebug(
         "Handling {ESV} (From: {Address}, TID: {TID:X4})",
         value.Message.ESV.ToSymbolString(),
         value.Address,
@@ -825,7 +825,7 @@ partial class EchonetClient
       if (value.Message.ESV != ESV.InfCResponse)
         return;
 
-      logger?.LogDebug(
+      Logger?.LogDebug(
         "Handling {ESV} (From: {Address}, TID: {TID:X4})",
         value.Message.ESV.ToSymbolString(),
         value.Address,

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.cs
@@ -50,10 +50,10 @@ public partial class EchonetClient : IEchonetClientService, IDisposable, IAsyncD
   TimeProvider? IEchonetClientService.TimeProvider => null; // TODO: make configurable, retrieve via IServiceProvider
 #endif
 
-  /// <inheritdoc cref="EchonetClient(EchonetNode, IEchonetLiteHandler, bool, IEchonetDeviceFactory, ResiliencePipeline, ILogger{EchonetClient})"/>
+  /// <inheritdoc cref="EchonetClient(EchonetNode, IEchonetLiteHandler, bool, IEchonetDeviceFactory, ResiliencePipeline, ILogger)"/>
   public EchonetClient(
     IEchonetLiteHandler echonetLiteHandler,
-    ILogger<EchonetClient>? logger = null
+    ILogger? logger = null
   )
     : this(
       echonetLiteHandler: echonetLiteHandler,
@@ -63,14 +63,14 @@ public partial class EchonetClient : IEchonetClientService, IDisposable, IAsyncD
   {
   }
 
-  /// <inheritdoc cref="EchonetClient(EchonetNode, IEchonetLiteHandler, bool, IEchonetDeviceFactory, ResiliencePipeline, ILogger{EchonetClient})"/>
+  /// <inheritdoc cref="EchonetClient(EchonetNode, IEchonetLiteHandler, bool, IEchonetDeviceFactory, ResiliencePipeline, ILogger)"/>
   /// <exception cref="ArgumentNullException">
   /// <paramref name="echonetLiteHandler"/>が<see langword="null"/>です。
   /// </exception>
   public EchonetClient(
     IEchonetLiteHandler echonetLiteHandler,
     bool shouldDisposeEchonetLiteHandler,
-    ILogger<EchonetClient>? logger
+    ILogger? logger
   )
     : this(
       selfNode: EchonetNode.CreateSelfNode(devices: Array.Empty<EchonetObject>()),
@@ -103,7 +103,7 @@ public partial class EchonetClient : IEchonetClientService, IDisposable, IAsyncD
     bool shouldDisposeEchonetLiteHandler,
     IEchonetDeviceFactory? deviceFactory,
     ResiliencePipeline? resiliencePipelineForSendingResponseFrame,
-    ILogger<EchonetClient>? logger
+    ILogger? logger
   )
   {
     this.shouldDisposeEchonetLiteHandler = shouldDisposeEchonetLiteHandler;

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetDevice.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetDevice.cs
@@ -108,7 +108,7 @@ public class EchonetDevice : EchonetObject {
       var added = properties.TryAdd(code, CreateProperty(code, canSet, canGet, canAnnounceStatusChange));
 
       if (added) {
-        Node.Owner?.Logger?.LogInformation(
+        Node.Owner?.Logger?.LogDebug(
           "New property added (Node: {NodeAddress}, EOJ: {EOJ}, EPC: {EPC:X2})",
           Node.Address,
           EOJ,
@@ -139,7 +139,7 @@ public class EchonetDevice : EchonetObject {
       var p = properties.GetOrAdd(property.Code, property);
 
       if (ReferenceEquals(p, property)) {
-        Node.Owner?.Logger?.LogInformation(
+        Node.Owner?.Logger?.LogDebug(
           "New property added (Node: {NodeAddress}, EOJ: {EOJ}, EPC: {EPC:X2})",
           Node.Address,
           EOJ,

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
@@ -89,76 +89,76 @@ public class EchonetPropertyTests {
   public void SetValue(byte[] newValue)
   {
     var p = CreateProperty();
-    var countOfValueChanged = 0;
+    var countOfValueUpdated = 0;
     var resetValue = new byte[] { 0xCD, 0xCD };
 
-    p.ValueChanged += (sender, val) => countOfValueChanged++;
+    p.ValueUpdated += (sender, val) => countOfValueUpdated++;
 
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueChanged)}");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
 
-    p.SetValue(newValue, raiseValueChangedEvent: false, setLastUpdatedTime: false);
+    p.SetValue(newValue, raiseValueUpdatedEvent: false, setLastUpdatedTime: false);
 
-    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueChanged)} #1");
-    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueChanged)} #1");
-    Assert.That(countOfValueChanged, Is.Zero, $"{nameof(countOfValueChanged)} after {nameof(p.ValueChanged)} #1");
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueChanged)}");
+    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueUpdated)} #1");
+    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueUpdated)} #1");
+    Assert.That(countOfValueUpdated, Is.Zero, $"{nameof(countOfValueUpdated)} after {nameof(p.ValueUpdated)} #1");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueUpdated)}");
 
     // reset
-    p.SetValue(resetValue, raiseValueChangedEvent: false, setLastUpdatedTime: false);
-    Assert.That(countOfValueChanged, Is.Zero, $"{nameof(countOfValueChanged)} after {nameof(p.ValueChanged)} #2");
+    p.SetValue(resetValue, raiseValueUpdatedEvent: false, setLastUpdatedTime: false);
+    Assert.That(countOfValueUpdated, Is.Zero, $"{nameof(countOfValueUpdated)} after {nameof(p.ValueUpdated)} #2");
 
     // set again
-    p.SetValue(newValue, raiseValueChangedEvent: false, setLastUpdatedTime: false);
+    p.SetValue(newValue, raiseValueUpdatedEvent: false, setLastUpdatedTime: false);
 
-    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueChanged)} #3");
-    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueChanged)} #3");
-    Assert.That(countOfValueChanged, Is.Zero, $"{nameof(countOfValueChanged)} after {nameof(p.ValueChanged)} #3");
+    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueUpdated)} #3");
+    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueUpdated)} #3");
+    Assert.That(countOfValueUpdated, Is.Zero, $"{nameof(countOfValueUpdated)} after {nameof(p.ValueUpdated)} #3");
   }
 
   [TestCaseSource(nameof(YieldTestCases_SetValue))]
-  public void SetValue_RaiseValueChangedEvent(byte[] newValue)
+  public void SetValue_RaiseValueUpdatedEvent(byte[] newValue)
   {
     var p = CreateProperty();
-    var countOfValueChanged = 0;
+    var countOfValueUpdated = 0;
     var resetValue = new byte[] { 0xCD, 0xCD };
 
 #pragma warning disable CS0618
-    p.ValueChanged += (sender, val) => {
+    p.ValueUpdated += (sender, val) => {
       Assert.That(p, Is.SameAs(sender), nameof(p));
-      Assert.That(p.ValueMemory, SequenceIs.EqualTo(val.NewValue), $"{nameof(p.ValueMemory)} on {nameof(p.ValueChanged)} #{countOfValueChanged}");
+      Assert.That(p.ValueMemory, SequenceIs.EqualTo(val.NewValue), $"{nameof(p.ValueMemory)} on {nameof(p.ValueUpdated)} #{countOfValueUpdated}");
 
       Assert.That(
         val.NewValue,
         SequenceIs.EqualTo(
-          countOfValueChanged switch {
+          countOfValueUpdated switch {
             0 or 2 => newValue.AsMemory(),
             1 => resetValue.AsMemory(),
             _ => throw new InvalidOperationException("unexpected event")
           }
         ),
-        $"{nameof(p.ValueMemory)} on {nameof(p.ValueChanged)} #{countOfValueChanged}"
+        $"{nameof(p.ValueMemory)} on {nameof(p.ValueUpdated)} #{countOfValueUpdated}"
       );
 
-      countOfValueChanged++;
+      countOfValueUpdated++;
     };
 #pragma warning restore CS0618
 
-    p.SetValue(newValue, raiseValueChangedEvent: true, setLastUpdatedTime: false);
+    p.SetValue(newValue, raiseValueUpdatedEvent: true, setLastUpdatedTime: false);
 
-    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueChanged)} #1");
-    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueChanged)} #1");
-    Assert.That(countOfValueChanged, Is.EqualTo(1), $"{nameof(countOfValueChanged)} after {nameof(p.ValueChanged)} #1");
+    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueUpdated)} #1");
+    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueUpdated)} #1");
+    Assert.That(countOfValueUpdated, Is.EqualTo(1), $"{nameof(countOfValueUpdated)} after {nameof(p.ValueUpdated)} #1");
 
     // reset
-    p.SetValue(resetValue, raiseValueChangedEvent: true, setLastUpdatedTime: false);
-    Assert.That(countOfValueChanged, Is.EqualTo(2), $"{nameof(countOfValueChanged)} after {nameof(p.ValueChanged)} #2");
+    p.SetValue(resetValue, raiseValueUpdatedEvent: true, setLastUpdatedTime: false);
+    Assert.That(countOfValueUpdated, Is.EqualTo(2), $"{nameof(countOfValueUpdated)} after {nameof(p.ValueUpdated)} #2");
 
     // set again
-    p.SetValue(newValue, raiseValueChangedEvent: true, setLastUpdatedTime: false);
+    p.SetValue(newValue, raiseValueUpdatedEvent: true, setLastUpdatedTime: false);
 
-    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueChanged)} #3");
-    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueChanged)} #3");
-    Assert.That(countOfValueChanged, Is.EqualTo(3), $"{nameof(countOfValueChanged)} after {nameof(p.ValueChanged)} #3");
+    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueUpdated)} #3");
+    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueUpdated)} #3");
+    Assert.That(countOfValueUpdated, Is.EqualTo(3), $"{nameof(countOfValueUpdated)} after {nameof(p.ValueUpdated)} #3");
   }
 
 #if SYSTEM_TIMEPROVIDER
@@ -168,13 +168,13 @@ public class EchonetPropertyTests {
     var setLastUpdatedTime = new DateTimeOffset(2024, 10, 3, 19, 40, 16, TimeSpan.FromHours(9.0));
     var p = CreateProperty(new PseudoConstantTimeProvider(setLastUpdatedTime));
 
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueChanged)}");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
 
-    p.SetValue(newValue, raiseValueChangedEvent: false, setLastUpdatedTime: true);
+    p.SetValue(newValue, raiseValueUpdatedEvent: false, setLastUpdatedTime: true);
 
-    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueChanged)} #1");
-    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueChanged)} #1");
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(setLastUpdatedTime), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueChanged)}");
+    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueUpdated)} #1");
+    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueUpdated)} #1");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(setLastUpdatedTime), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueUpdated)}");
   }
 #endif
 
@@ -198,76 +198,76 @@ public class EchonetPropertyTests {
   public void WriteValue(byte[] newValue)
   {
     var p = CreateProperty();
-    var countOfValueChanged = 0;
+    var countOfValueUpdated = 0;
     var resetValue = new byte[] { 0xCD, 0xCD };
 
-    p.ValueChanged += (sender, val) => countOfValueChanged++;
+    p.ValueUpdated += (sender, val) => countOfValueUpdated++;
 
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueChanged)}");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
 
-    p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueChangedEvent: false, setLastUpdatedTime: false);
+    p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueUpdatedEvent: false, setLastUpdatedTime: false);
 
     Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.WriteValue)} #1");
     Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.WriteValue)} #1");
-    Assert.That(countOfValueChanged, Is.Zero, $"{nameof(countOfValueChanged)} after {nameof(p.WriteValue)} #1");
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueChanged)}");
+    Assert.That(countOfValueUpdated, Is.Zero, $"{nameof(countOfValueUpdated)} after {nameof(p.WriteValue)} #1");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueUpdated)}");
 
     // reset
-    p.SetValue(resetValue, raiseValueChangedEvent: false, setLastUpdatedTime: false);
-    Assert.That(countOfValueChanged, Is.Zero, $"{nameof(countOfValueChanged)} after {nameof(p.WriteValue)} #2");
+    p.SetValue(resetValue, raiseValueUpdatedEvent: false, setLastUpdatedTime: false);
+    Assert.That(countOfValueUpdated, Is.Zero, $"{nameof(countOfValueUpdated)} after {nameof(p.WriteValue)} #2");
 
     // write again
-    p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueChangedEvent: false, setLastUpdatedTime: false);
+    p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueUpdatedEvent: false, setLastUpdatedTime: false);
 
     Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.WriteValue)} #3");
     Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.WriteValue)} #3");
-    Assert.That(countOfValueChanged, Is.Zero, $"{nameof(countOfValueChanged)} after {nameof(p.WriteValue)} #3");
+    Assert.That(countOfValueUpdated, Is.Zero, $"{nameof(countOfValueUpdated)} after {nameof(p.WriteValue)} #3");
   }
 
   [TestCaseSource(nameof(YieldTestCases_WriteValue))]
-  public void WriteValue_RaiseValueChangedEvent(byte[] newValue)
+  public void WriteValue_RaiseValueUpdatedEvent(byte[] newValue)
   {
     var p = CreateProperty();
-    var countOfValueChanged = 0;
+    var countOfValueUpdated = 0;
     var resetValue = new byte[] { 0xCD, 0xCD };
 
 #pragma warning disable CS0618
-    p.ValueChanged += (sender, val) => {
+    p.ValueUpdated += (sender, val) => {
       Assert.That(p, Is.SameAs(sender), nameof(p));
-      Assert.That(p.ValueMemory, SequenceIs.EqualTo(val.NewValue), $"{nameof(p.ValueMemory)} on {nameof(p.ValueChanged)} #{countOfValueChanged}");
+      Assert.That(p.ValueMemory, SequenceIs.EqualTo(val.NewValue), $"{nameof(p.ValueMemory)} on {nameof(p.ValueUpdated)} #{countOfValueUpdated}");
 
       Assert.That(
         val.NewValue,
         SequenceIs.EqualTo(
-          countOfValueChanged switch {
+          countOfValueUpdated switch {
             0 or 2 => newValue.AsMemory(),
             1 => resetValue.AsMemory(),
             _ => throw new InvalidOperationException("unexpected event")
           }
         ),
-        $"{nameof(p.ValueMemory)} on {nameof(p.ValueChanged)} #{countOfValueChanged}"
+        $"{nameof(p.ValueMemory)} on {nameof(p.ValueUpdated)} #{countOfValueUpdated}"
       );
 
-      countOfValueChanged++;
+      countOfValueUpdated++;
     };
 #pragma warning restore CS0618
 
-    p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueChangedEvent: true, setLastUpdatedTime: false);
+    p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueUpdatedEvent: true, setLastUpdatedTime: false);
 
     Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.WriteValue)} #1");
     Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.WriteValue)} #1");
-    Assert.That(countOfValueChanged, Is.EqualTo(1), $"{nameof(countOfValueChanged)} after {nameof(p.WriteValue)} #1");
+    Assert.That(countOfValueUpdated, Is.EqualTo(1), $"{nameof(countOfValueUpdated)} after {nameof(p.WriteValue)} #1");
 
     // reset
-    p.SetValue(resetValue, raiseValueChangedEvent: true, setLastUpdatedTime: false);
-    Assert.That(countOfValueChanged, Is.EqualTo(2), $"{nameof(countOfValueChanged)} after {nameof(p.WriteValue)} #2");
+    p.SetValue(resetValue, raiseValueUpdatedEvent: true, setLastUpdatedTime: false);
+    Assert.That(countOfValueUpdated, Is.EqualTo(2), $"{nameof(countOfValueUpdated)} after {nameof(p.WriteValue)} #2");
 
     // write again
-    p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueChangedEvent: true, setLastUpdatedTime: false);
+    p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueUpdatedEvent: true, setLastUpdatedTime: false);
 
     Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.WriteValue)} #3");
     Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.WriteValue)} #3");
-    Assert.That(countOfValueChanged, Is.EqualTo(3), $"{nameof(countOfValueChanged)} after {nameof(p.WriteValue)} #3");
+    Assert.That(countOfValueUpdated, Is.EqualTo(3), $"{nameof(countOfValueUpdated)} after {nameof(p.WriteValue)} #3");
   }
 
 #if SYSTEM_TIMEPROVIDER
@@ -277,17 +277,17 @@ public class EchonetPropertyTests {
     var setLastUpdatedTime = new DateTimeOffset(2024, 10, 3, 19, 40, 16, TimeSpan.FromHours(9.0));
     var p = CreateProperty(new PseudoConstantTimeProvider(setLastUpdatedTime));
 
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueChanged)}");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
 
-    p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueChangedEvent: false, setLastUpdatedTime: true);
+    p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueUpdatedEvent: false, setLastUpdatedTime: true);
 
-    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueChanged)} #1");
-    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueChanged)} #1");
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(setLastUpdatedTime), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueChanged)}");
+    Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueUpdated)} #1");
+    Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueUpdated)} #1");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(setLastUpdatedTime), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueUpdated)}");
   }
 #endif
 
-  private static System.Collections.IEnumerable YieldTestCases_ValueChanged_InitialSet()
+  private static System.Collections.IEnumerable YieldTestCases_ValueUpdated_InitialSet()
   {
     yield return new object?[] { new byte[0] };
     yield return new object?[] { new byte[] { 0xFF } };
@@ -295,33 +295,33 @@ public class EchonetPropertyTests {
     yield return new object?[] { Enumerable.Range(0x00, 0x100).Select(static i => (byte)i).ToArray() };
   }
 
-  [TestCaseSource(nameof(YieldTestCases_ValueChanged_InitialSet))]
-  public void ValueChanged_InitialSet(byte[] newValue)
+  [TestCaseSource(nameof(YieldTestCases_ValueUpdated_InitialSet))]
+  public void ValueUpdated_InitialSet(byte[] newValue)
   {
     var p = CreateProperty();
 
-    var countOfValueChanged = 0;
+    var countOfValueUpdated = 0;
 
-    p.ValueChanged += (sender, e) => {
+    p.ValueUpdated += (sender, e) => {
       Assert.That(p, Is.SameAs(sender), nameof(p));
 
       Assert.That(e.OldValue, SequenceIs.EqualTo(ReadOnlyMemory<byte>.Empty), nameof(e.OldValue));
       Assert.That(e.NewValue, SequenceIs.EqualTo(newValue), nameof(e.NewValue));
 
-      countOfValueChanged++;
+      countOfValueUpdated++;
     };
 
-    Assert.DoesNotThrow(() => p.SetValue(newValue.AsMemory(), raiseValueChangedEvent: true));
+    Assert.DoesNotThrow(() => p.SetValue(newValue.AsMemory(), raiseValueUpdatedEvent: true));
 
-    Assert.That(countOfValueChanged, Is.EqualTo(1), $"{nameof(countOfValueChanged)} #1");
+    Assert.That(countOfValueUpdated, Is.EqualTo(1), $"{nameof(countOfValueUpdated)} #1");
 
     // set same value again
     Assert.DoesNotThrow(() => p.SetValue(newValue.AsMemory()));
 
-    Assert.That(countOfValueChanged, Is.EqualTo(1), $"{nameof(countOfValueChanged)} #2");
+    Assert.That(countOfValueUpdated, Is.EqualTo(1), $"{nameof(countOfValueUpdated)} #2");
   }
 
-  private static System.Collections.IEnumerable YieldTestCases_ValueChanged_DifferentValue()
+  private static System.Collections.IEnumerable YieldTestCases_ValueUpdated_DifferentValue()
   {
     yield return new object?[] { new byte[] { 0x00 } };
     yield return new object?[] { new byte[] { 0xFF } };
@@ -329,32 +329,45 @@ public class EchonetPropertyTests {
     yield return new object?[] { Enumerable.Range(0x00, 0x100).Select(static i => (byte)i).ToArray() };
   }
 
-  [TestCaseSource(nameof(YieldTestCases_ValueChanged_DifferentValue))]
-  public void ValueChanged_DifferentValue(byte[] newValue)
+  [TestCaseSource(nameof(YieldTestCases_ValueUpdated_DifferentValue))]
+  public void ValueUpdated_DifferentValue(byte[] newValue)
   {
     var initialValue = new byte[] { 0xDE, 0xAD, 0xBE, 0xAF };
     var p = CreateProperty();
 
-    p.SetValue(initialValue.AsMemory(), raiseValueChangedEvent: true);
+    p.SetValue(initialValue.AsMemory(), raiseValueUpdatedEvent: true);
 
-    var countOfValueChanged = 0;
+    var countOfValueUpdated = 0;
 
-    p.ValueChanged += (sender, e) => {
+    p.ValueUpdated += (sender, e) => {
       Assert.That(p, Is.SameAs(sender), nameof(p));
 
-      Assert.That(e.OldValue, SequenceIs.EqualTo(initialValue), nameof(e.OldValue));
+      switch (countOfValueUpdated) {
+        case 0:
+          Assert.That(e.OldValue, SequenceIs.EqualTo(initialValue), nameof(e.OldValue));
+          break;
+
+        case 1:
+          Assert.That(e.OldValue, SequenceIs.EqualTo(newValue), nameof(e.OldValue));
+          break;
+
+        default:
+          Assert.Fail("extra ValueUpdated event raised");
+          break;
+      }
+
       Assert.That(e.NewValue, SequenceIs.EqualTo(newValue), nameof(e.NewValue));
 
-      countOfValueChanged++;
+      countOfValueUpdated++;
     };
 
-    Assert.DoesNotThrow(() => p.SetValue(newValue.AsMemory(), raiseValueChangedEvent: true));
+    Assert.DoesNotThrow(() => p.SetValue(newValue.AsMemory(), raiseValueUpdatedEvent: true));
 
-    Assert.That(countOfValueChanged, Is.EqualTo(1), $"{nameof(countOfValueChanged)} #1");
+    Assert.That(countOfValueUpdated, Is.EqualTo(1), $"{nameof(countOfValueUpdated)} #1");
 
     // set same value again
-    Assert.DoesNotThrow(() => p.SetValue(newValue.AsMemory(), raiseValueChangedEvent: true));
+    Assert.DoesNotThrow(() => p.SetValue(newValue.AsMemory(), raiseValueUpdatedEvent: true));
 
-    Assert.That(countOfValueChanged, Is.EqualTo(1), $"{nameof(countOfValueChanged)} #2");
+    Assert.That(countOfValueUpdated, Is.EqualTo(2), $"{nameof(countOfValueUpdated)} #2");
   }
 }


### PR DESCRIPTION
### Description
現状のイベント`EchonetProperty.ValueChanged`では、値の変更があった場合のみを検知できる。
このイベントでは、サービス要求等によって最新の状態に更新された(が、値自体の変更はない)ことが検知できない。

そこで、新たにイベント`EchonetProperty.ValueUpdated`を導入し、プロパティ値の変更有無に関わらず、プロパティ値が更新されたことを検知できるようにする。
ここで、更新に際して値に変更があったかどうかは、イベント引数を用いて判断できるようにする。

また、ValueChangedイベントは不要になるため、ValueUpdatedに統合する。