### PR TITLE
EchonetNodeRegistryを導入する

### DIFF
--- a/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.AIF.cs
+++ b/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.AIF.cs
@@ -202,6 +202,7 @@ partial class HemsController {
     EchonetObject ControllerObject
   )
   CreateEchonetObject(
+    EchonetNodeRegistry nodeRegistry,
     IEchonetLiteHandler echonetLiteHandler,
     ILoggerFactory? loggerFactoryForEchonetClient
   )
@@ -228,6 +229,7 @@ partial class HemsController {
       selfNode: controllerNode,
       echonetLiteHandler: echonetLiteHandler,
       shouldDisposeEchonetLiteHandler: ShouldDisposeEchonetLiteHandlerByClient,
+      nodeRegistry: nodeRegistry,
       deviceFactory: RouteBDeviceFactory.Instance,
       resiliencePipelineForSendingResponseFrame: null, // TODO: make configurable
       logger: loggerFactoryForEchonetClient?.CreateLogger<EchonetClient>()
@@ -272,6 +274,7 @@ partial class HemsController {
       Logger?.LogInformation("Route-B connection established.");
 
       (client, controllerObject) = CreateEchonetObject(
+        nodeRegistry,
         echonetLiteHandler,
         loggerFactoryForEchonetClient
       );
@@ -520,7 +523,8 @@ partial class HemsController {
 #pragma warning disable CS8602
 #endif
     var lvsm = client
-      .OtherNodes
+      .NodeRegistry
+      .Nodes
       .FirstOrDefault(n => n.Address.Equals(smartMeterNodeAddress))
       ?.Devices
       ?.OfType<LowVoltageSmartElectricEnergyMeter>()

--- a/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.cs
+++ b/src/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB/HemsController.cs
@@ -33,6 +33,7 @@ namespace Smdn.Net.EchonetLite.RouteB;
 /// APPENDIX ECHONET 機器オブジェクト詳細規定 Release R
 /// </seealso>
 public partial class HemsController : IRouteBCredentialIdentity, IDisposable, IAsyncDisposable {
+  private readonly EchonetNodeRegistry nodeRegistry;
   private readonly IRouteBEchonetLiteHandlerFactory echonetLiteHandlerFactory;
   private readonly IRouteBCredentialProvider credentialProvider;
   private readonly ILoggerFactory? loggerFactoryForEchonetClient;
@@ -120,6 +121,7 @@ public partial class HemsController : IRouteBCredentialIdentity, IDisposable, IA
       throw new ArgumentNullException(nameof(routeBCredentialProvider));
 #pragma warning restore CA1510
 
+    nodeRegistry = new();
     this.echonetLiteHandlerFactory = echonetLiteHandlerFactory;
     credentialProvider = routeBCredentialProvider;
     Logger = logger;

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Events.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetClient.Events.cs
@@ -26,17 +26,6 @@ partial class EchonetClient
   }
 
   /// <summary>
-  /// 新しいECHONET Lite ノードが発見されたときに発生するイベント。
-  /// </summary>
-  /// <remarks>
-  /// イベント引数には、発見されたノードを表す<see cref="EchonetNode"/>が設定されます。
-  /// </remarks>
-  public event EventHandler<EchonetNode>? NodeJoined;
-
-  protected virtual void OnNodeJoined(EchonetNode node)
-    => RaiseEvent(NodeJoined, node);
-
-  /// <summary>
   /// インスタンスリスト通知の受信による更新を開始するときに発生するイベント。
   /// </summary>
   /// <remarks>

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetNode.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetNode.cs
@@ -44,14 +44,13 @@ public abstract class EchonetNode {
   /// <summary>
   /// 現在このインスタンスを管理している<see cref="IEchonetClientService"/>を取得します。
   /// </summary>
-  internal IEchonetClientService? Owner { get; set; }
+  internal IEchonetClientService? Owner { get; private set; }
 
   /// <summary>
   /// このインスタンスでイベントを発生させるために使用される<see cref="IEventInvoker"/>を取得します。
   /// </summary>
   /// <exception cref="InvalidOperationException"><see cref="IEventInvoker"/>を取得することができません。</exception>
-  internal IEventInvoker EventInvoker
-    => Owner ?? throw new InvalidOperationException($"{nameof(EventInvoker)} can not be null.");
+  internal IEventInvoker EventInvoker => GetOwnerOrThrow();
 
   /// <summary>
   /// 下位スタックのアドレスを表す<see cref="IPAddress"/>を取得します。
@@ -83,6 +82,15 @@ public abstract class EchonetNode {
     NodeProfile = nodeProfile ?? throw new ArgumentNullException(nameof(nodeProfile));
     NodeProfile.OwnerNode = this;
   }
+
+  internal void SetOwner(IEchonetClientService newOwner)
+    => Owner = newOwner ?? throw new ArgumentNullException(nameof(newOwner));
+
+  internal void UnsetOwner()
+    => Owner = null;
+
+  internal IEchonetClientService GetOwnerOrThrow()
+    => Owner ?? throw new InvalidOperationException($"The {nameof(IEchonetClientService)} currently associated with this instance has been disposed or is not yet associated.");
 
   internal abstract EchonetObject? FindDevice(EOJ eoj);
 

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetNodeRegistry.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetNodeRegistry.cs
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+
+namespace Smdn.Net.EchonetLite;
+
+/// <summary>
+/// <see cref="EchonetClient"/>のライフサイクルを超えて、既知のECHONETノードの情報を保持するため機構を提供します。
+/// </summary>
+/// <remarks>
+/// <see cref="EchonetClient"/>を破棄したあと、再接続以降にも引き続き同じ<see cref="EchonetNode"/>インスタンスを
+/// 使用する必要がある場合は、既知の<see cref="EchonetNode"/>をこのクラスで保持することができます。
+/// <see cref="EchonetNode"/>で保持される<see cref="EchonetObject"/>も同時に保持されます。
+/// </remarks>
+/// <seealso cref="EchonetNode"/>
+public sealed class EchonetNodeRegistry {
+  /// <summary>
+  /// 新しいECHONET Lite ノードが追加されたときに発生するイベント。
+  /// </summary>
+  /// <remarks>
+  /// イベント引数には、発見されたノードを表す<see cref="EchonetNode"/>が設定されます。
+  /// </remarks>
+  public event EventHandler<EchonetNode>? NodeAdded;
+
+  /// <summary>
+  /// 既知のECHONET Lite ノード(他ノード)のコレクションを表す<see cref="IReadOnlyCollection{EchonetNode}"/>を取得します。
+  /// </summary>
+  /// <remarks>
+  /// インスタンスリスト通知要求等、一斉同報送信を行うなどの契機で新しいECHONET Lite ノードが追加された場合は、
+  /// イベント<see cref="NodeAdded"/>が発生します。
+  /// </remarks>
+  /// <seealso cref="EchonetClient.RequestNotifyInstanceListAsync"/>
+  /// <seealso cref="NodeAdded"/>
+  public IReadOnlyCollection<EchonetNode> Nodes => readOnlyNodesView.Values;
+
+  private readonly ConcurrentDictionary<IPAddress, EchonetOtherNode> nodes;
+  private readonly ReadOnlyDictionary<IPAddress, EchonetOtherNode> readOnlyNodesView;
+
+  private IEchonetClientService? owner;
+
+  public EchonetNodeRegistry()
+  {
+    nodes = new();
+    readOnlyNodesView = new(nodes);
+  }
+
+  internal bool TryResolve(
+    IPAddress address,
+    [NotNullWhen(true)] out EchonetOtherNode? node
+  )
+    => nodes.TryGetValue(address, out node);
+
+  internal bool TryAdd(
+    IPAddress address,
+    EchonetOtherNode newNode,
+    out EchonetOtherNode addedNode
+  )
+  {
+#if DEBUG
+    if (owner is null)
+      throw new InvalidOperationException($"{nameof(owner)} is null");
+#endif
+
+    addedNode = nodes.GetOrAdd(address, newNode);
+
+    if (ReferenceEquals(newNode, addedNode)) {
+      addedNode.SetOwner(
+        owner
+#if !DEBUG
+        !
+#endif
+      );
+
+      OnNodeAdded(addedNode);
+
+      return true;
+    }
+
+    return false;
+  }
+
+  private void OnNodeAdded(EchonetNode node)
+    => GetOwnerOrThrow().InvokeEvent(this, NodeAdded, node);
+
+  internal void SetOwner(IEchonetClientService newOwner)
+  {
+    owner = newOwner;
+
+    if (newOwner is null)
+      throw new ArgumentNullException(nameof(newOwner));
+
+    foreach (var node in nodes.Values) {
+      node.SetOwner(newOwner);
+    }
+  }
+
+  internal void UnsetOwner()
+  {
+    owner = null;
+
+    foreach (var node in nodes.Values) {
+      node.UnsetOwner();
+    }
+  }
+
+  private IEchonetClientService GetOwnerOrThrow()
+    => owner ?? throw new InvalidOperationException($"This instance is not associated with any {nameof(IEchonetClientService)}.");
+}

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObjectExtensions.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObjectExtensions.cs
@@ -14,7 +14,7 @@ namespace Smdn.Net.EchonetLite;
 
 public static class EchonetObjectExtensions {
   private static IEchonetClientService GetClientServiceOrThrow(EchonetObject obj)
-    => obj.OwnerNode?.Owner ?? throw new InvalidOperationException("could not get client");
+    => obj.OwnerNode.GetOwnerOrThrow();
 
   private static InvalidOperationException CreateCanNotSpecifySelfNodeAsDestination()
     => new("Can not specify the self node as the destination.");

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetOtherNode.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetOtherNode.cs
@@ -22,10 +22,9 @@ internal sealed class EchonetOtherNode : EchonetNode {
   private readonly ConcurrentDictionary<EOJ, EchonetObject> devices;
   private readonly ReadOnlyDictionary<EOJ, EchonetObject> readOnlyDevicesView;
 
-  internal EchonetOtherNode(IEchonetClientService owner, IPAddress address, EchonetObject nodeProfile)
+  internal EchonetOtherNode(IPAddress address, EchonetObject nodeProfile)
     : base(nodeProfile)
   {
-    Owner = owner ?? throw new ArgumentNullException(nameof(owner));
     Address = address ?? throw new ArgumentNullException(nameof(address));
 
     devices = new();


### PR DESCRIPTION
### Description
現状の`EchonetClient`では、`EchonetClient`と`EchonetNode`は常に同じライフサイクルとなる。
例として再接続を行う場合は、その前後で`EchonetNode`が異なるインスタンスとなる。
したがって、`EchonetClient`のライフサイクルを超えて、ノード、ノードに属する機器オブジェクト、機器オブジェクトの各プロパティの状態を維持ないし引き継ぐことができない。

そこで、新たに`EchonetNodeRegistry`を導入する。
`EchonetNodeRegistry`は、発見された/既知のECHONETノードに対応する`EchonetNode`インスタンスを保持する。

`EchonetClient`は任意の`EchonetNodeRegistry`の参照を保持し、ノードが発見された場合は`EchonetNodeRegistry`から既知の`EchonetNode`インスタンスを取得するか、未知の場合は新たに`EchonetNode`インスタンスを作成して登録する。
これにより、`EchonetClient`のライフサイクルを超えてECHONETノードと`EchonetNode`インスタンスの対応を保持し、再接続等を行っても`EchonetNode`インスタンスを引き続き利用可能となるようにする。
