### PR TITLE
EchonetObject.PropertyValueUpdatedを追加する

### DIFF
--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
@@ -126,17 +126,17 @@ public abstract class EchonetProperty {
   public ReadOnlySpan<byte> ValueSpan => value is null ? ReadOnlySpan<byte>.Empty : value.WrittenSpan;
 
   /// <summary>
-  /// プロパティ値データ(EDT)を更新した時刻を表す<see cref="DateTimeOffset"/>を取得します。
+  /// プロパティ値データ(EDT)を更新した時刻を表す<see cref="DateTime"/>を取得します。
   /// </summary>
   /// <remarks>
-  /// このプロパティは、他ノードに属するECHONETオブジェクトのプロパティ値を更新した時刻を保持します。
+  /// このプロパティは、他ノードに属するECHONETオブジェクトのプロパティ値を更新した時刻(ローカル時刻)を保持します。
   /// 具体的には、次の状況でプロパティ値を取得した時刻・通知された時刻を保持します。
   /// <list type="bullet">
   ///   <item>他ノードに属するECHONETオブジェクトに対するプロパティ値の読み出し・通知要求に対する応答</item>
   ///   <item>他ノードに属するECHONETオブジェクトからのプロパティ値通知</item>
   /// </list>
   /// </remarks>
-  public DateTimeOffset LastUpdatedTime { get; private set; }
+  public DateTime LastUpdatedTime { get; private set; }
 
   /// <summary>
   /// プロパティ値データ(EDT)が変更されているかどうかを表す<see cref="bool"/>型の値を返します。
@@ -355,9 +355,9 @@ public abstract class EchonetProperty {
       if (setLastUpdatedTime) {
         LastUpdatedTime =
 #if SYSTEM_TIMEPROVIDER
-          TimeProvider.GetLocalNow();
+          TimeProvider.GetLocalNow().LocalDateTime;
 #else
-          DateTimeOffset.Now;
+          DateTime.Now;
 #endif
       }
 

--- a/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetPropertyValueUpdatedEventArgs.cs
+++ b/src/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetPropertyValueUpdatedEventArgs.cs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Net.EchonetLite;
+
+/// <summary>
+/// <see cref="EchonetProperty"/>が保持しているプロパティ値データ(EDT)が更新された場合に発生するイベントのデータを提供します。
+/// </summary>
+/// <see cref="EchonetProperty.ValueUpdated"/>
+public sealed class EchonetPropertyValueUpdatedEventArgs : EventArgs {
+  /// <summary>
+  /// プロパティ値が更新されたプロパティを表す<see cref="EchonetProperty"/>。
+  /// </summary>
+  public EchonetProperty Property { get; }
+
+  /// <summary>
+  /// プロパティ値が更新される前の<see cref="EchonetProperty.ValueMemory"/>の値。
+  /// </summary>
+  public ReadOnlyMemory<byte> OldValue { get; }
+
+  /// <summary>
+  /// プロパティ値が更新された後の<see cref="EchonetProperty.ValueMemory"/>の値。
+  /// </summary>
+  public ReadOnlyMemory<byte> NewValue { get; }
+
+  /// <summary>
+  /// プロパティ値が更新される前の<see cref="EchonetProperty.LastUpdatedTime"/>の値。
+  /// </summary>
+  public DateTime PreviousUpdatedTime { get; }
+
+  /// <summary>
+  /// プロパティ値が更新された時点の<see cref="EchonetProperty.LastUpdatedTime"/>の値。
+  /// </summary>
+  public DateTime UpdatedTime { get; }
+
+  public EchonetPropertyValueUpdatedEventArgs(
+    EchonetProperty property,
+    ReadOnlyMemory<byte> oldValue,
+    ReadOnlyMemory<byte> newValue,
+    DateTime previousUpdatedTime,
+    DateTime updatedTime
+  )
+  {
+    Property = property ?? throw new ArgumentNullException(nameof(property));
+    OldValue = oldValue;
+    NewValue = newValue;
+    PreviousUpdatedTime = previousUpdatedTime;
+    UpdatedTime = updatedTime;
+  }
+}

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetObject.cs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+using NUnit.Framework;
+
+using Smdn.Net.EchonetLite.ComponentModel;
+
+using SequenceIs = Smdn.Test.NUnit.Constraints.Buffers.Is;
+
+namespace Smdn.Net.EchonetLite;
+
+[TestFixture]
+public class EchonetObjectTests {
+  private class PseudoEventInvoker : IEventInvoker {
+    public ISynchronizeInvoke? SynchronizingObject { get; set; }
+
+    public void InvokeEvent<TEventArgs>(object? sender, EventHandler<TEventArgs>? eventHandler, TEventArgs e)
+      => eventHandler?.Invoke(sender, e);
+  }
+
+  private class PseudoDevice : EchonetDevice {
+    protected override IEventInvoker EventInvoker { get; } = new PseudoEventInvoker();
+
+    public PseudoDevice()
+      : base(
+        classGroupCode: 0x00,
+        classCode: 0x00,
+        instanceCode: 0x00
+      )
+    {
+    }
+
+    public new EchonetProperty CreateProperty(byte propertyCode)
+      => base.CreateProperty(
+        propertyCode: propertyCode,
+        canSet: true,
+        canGet: true,
+        canAnnounceStatusChange: true
+      );
+  }
+
+  [Test]
+  public void PropertyValueUpdated()
+  {
+    var device = new PseudoDevice();
+    var p = device.CreateProperty(0x00);
+
+    var newValue = new byte[] { 0x00 };
+    var countOfValueUpdated = 0;
+    var expectedPreviousUpdatedTime = default(DateTime);
+
+    device.PropertyValueUpdated += (sender, e) => {
+      Assert.That(sender, Is.SameAs(device), nameof(sender));
+      Assert.That(e.Property, Is.SameAs(p), nameof(e.Property));
+
+      switch (countOfValueUpdated) {
+        case 0:
+          Assert.That(e.OldValue, SequenceIs.EqualTo(default(ReadOnlyMemory<byte>)), nameof(e.OldValue));
+          Assert.That(e.NewValue, SequenceIs.EqualTo(newValue), nameof(e.NewValue));
+          Assert.That(e.PreviousUpdatedTime, Is.EqualTo(expectedPreviousUpdatedTime), nameof(e.PreviousUpdatedTime));
+          Assert.That(e.UpdatedTime, Is.GreaterThan(e.PreviousUpdatedTime), nameof(e.UpdatedTime));
+
+          expectedPreviousUpdatedTime = e.UpdatedTime;
+
+          break;
+
+        case 1:
+          Assert.That(e.OldValue, SequenceIs.EqualTo(newValue), nameof(e.OldValue));
+          Assert.That(e.NewValue, SequenceIs.EqualTo(newValue), nameof(e.NewValue));
+          Assert.That(e.PreviousUpdatedTime, Is.EqualTo(expectedPreviousUpdatedTime), nameof(e.PreviousUpdatedTime));
+          Assert.That(e.UpdatedTime, Is.GreaterThan(e.PreviousUpdatedTime), nameof(e.UpdatedTime));
+          break;
+
+        default:
+          Assert.Fail("extra ValueUpdated event raised");
+          break;
+      }
+
+      countOfValueUpdated++;
+    };
+
+    Assert.DoesNotThrow(() => p.SetValue(newValue.AsMemory(), raiseValueUpdatedEvent: true, setLastUpdatedTime: true));
+
+    Assert.That(countOfValueUpdated, Is.EqualTo(1), $"{nameof(countOfValueUpdated)} #1");
+
+    // set same value again
+    Assert.DoesNotThrow(() => p.SetValue(newValue.AsMemory(), raiseValueUpdatedEvent: true, setLastUpdatedTime: true));
+
+    Assert.That(countOfValueUpdated, Is.EqualTo(2), $"{nameof(countOfValueUpdated)} #2");
+  }
+}

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
@@ -17,8 +17,10 @@ namespace Smdn.Net.EchonetLite;
 [TestFixture]
 public class EchonetPropertyTests {
 #if SYSTEM_TIMEPROVIDER
-  private class PseudoConstantTimeProvider(DateTimeOffset localNow) : TimeProvider {
-    public override DateTimeOffset GetUtcNow() => localNow.ToUniversalTime();
+  private class PseudoConstantTimeProvider(DateTime localNow) : TimeProvider {
+    private readonly DateTimeOffset LocalNow = new DateTimeOffset(localNow, TimeZoneInfo.Local.BaseUtcOffset);
+
+    public override DateTimeOffset GetUtcNow() => LocalNow.ToUniversalTime();
   }
 #endif
 
@@ -97,14 +99,14 @@ public class EchonetPropertyTests {
 
     p.ValueUpdated += (sender, val) => countOfValueUpdated++;
 
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTime)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
 
     p.SetValue(newValue, raiseValueUpdatedEvent: false, setLastUpdatedTime: false);
 
     Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueUpdated)} #1");
     Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueUpdated)} #1");
     Assert.That(countOfValueUpdated, Is.Zero, $"{nameof(countOfValueUpdated)} after {nameof(p.ValueUpdated)} #1");
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueUpdated)}");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTime)), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueUpdated)}");
 
     // reset
     p.SetValue(resetValue, raiseValueUpdatedEvent: false, setLastUpdatedTime: false);
@@ -168,16 +170,17 @@ public class EchonetPropertyTests {
   [TestCaseSource(nameof(YieldTestCases_SetValue))]
   public void SetValue_SetLastUpdatedTime(byte[] newValue)
   {
-    var setLastUpdatedTime = new DateTimeOffset(2024, 10, 3, 19, 40, 16, TimeSpan.FromHours(9.0));
+    var setLastUpdatedTime = new DateTime(2024, 10, 3, 19, 40, 16, DateTimeKind.Local);
     var p = CreateProperty(new PseudoConstantTimeProvider(setLastUpdatedTime));
 
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTime)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
 
     p.SetValue(newValue, raiseValueUpdatedEvent: false, setLastUpdatedTime: true);
 
     Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueUpdated)} #1");
     Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueUpdated)} #1");
     Assert.That(p.LastUpdatedTime, Is.EqualTo(setLastUpdatedTime), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueUpdated)}");
+    Assert.That(p.LastUpdatedTime.Kind, Is.EqualTo(DateTimeKind.Local));
   }
 #endif
 
@@ -206,14 +209,14 @@ public class EchonetPropertyTests {
 
     p.ValueUpdated += (sender, val) => countOfValueUpdated++;
 
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTime)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
 
     p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueUpdatedEvent: false, setLastUpdatedTime: false);
 
     Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.WriteValue)} #1");
     Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.WriteValue)} #1");
     Assert.That(countOfValueUpdated, Is.Zero, $"{nameof(countOfValueUpdated)} after {nameof(p.WriteValue)} #1");
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueUpdated)}");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTime)), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueUpdated)}");
 
     // reset
     p.SetValue(resetValue, raiseValueUpdatedEvent: false, setLastUpdatedTime: false);
@@ -277,16 +280,17 @@ public class EchonetPropertyTests {
   [TestCaseSource(nameof(YieldTestCases_WriteValue))]
   public void WriteValue_SetLastUpdatedTime(byte[] newValue)
   {
-    var setLastUpdatedTime = new DateTimeOffset(2024, 10, 3, 19, 40, 16, TimeSpan.FromHours(9.0));
+    var setLastUpdatedTime = new DateTime(2024, 10, 3, 19, 40, 16, DateTimeKind.Local);
     var p = CreateProperty(new PseudoConstantTimeProvider(setLastUpdatedTime));
 
-    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTimeOffset)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
+    Assert.That(p.LastUpdatedTime, Is.EqualTo(default(DateTime)), $"{nameof(p.LastUpdatedTime)} before {nameof(p.ValueUpdated)}");
 
     p.WriteValue(writer => writer.Write(newValue.AsSpan()), raiseValueUpdatedEvent: false, setLastUpdatedTime: true);
 
     Assert.That(p.ValueMemory, SequenceIs.EqualTo(newValue), $"{nameof(p.ValueMemory)} after {nameof(p.ValueUpdated)} #1");
     Assert.That(p.ValueSpan.ToArray(), SequenceIs.EqualTo(newValue), $"{nameof(p.ValueSpan)} after {nameof(p.ValueUpdated)} #1");
     Assert.That(p.LastUpdatedTime, Is.EqualTo(setLastUpdatedTime), $"{nameof(p.LastUpdatedTime)} after {nameof(p.ValueUpdated)}");
+    Assert.That(p.LastUpdatedTime.Kind, Is.EqualTo(DateTimeKind.Local));
   }
 #endif
 

--- a/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
+++ b/tests/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/EchonetProperty.cs
@@ -31,9 +31,21 @@ public class EchonetPropertyTests {
       => eventHandler?.Invoke(sender, e);
   }
 
-  private class PseudoProperty : EchonetProperty {
-    public override EchonetObject Device => throw new NotImplementedException();
+  private class PseudoDevice : EchonetDevice {
     protected override IEventInvoker EventInvoker { get; } = new PseudoEventInvoker();
+
+    public PseudoDevice()
+      : base(
+        classGroupCode: 0x00,
+        classCode: 0x00,
+        instanceCode: 0x00
+      )
+    {
+    }
+  }
+
+  private class PseudoProperty : EchonetProperty {
+    public override EchonetObject Device { get; } = new PseudoDevice();
 
 #if SYSTEM_TIMEPROVIDER
     protected override TimeProvider TimeProvider { get; }


### PR DESCRIPTION
### Description
プロパティ単位で値の更新を感知する`EchonetProperty.ValueUpdated`とは別に、オブジェクト単位で各プロパティの値の更新を感知・処理できるようにするため、`EchonetObject.PropertyValueUpdated`を追加する。

これに伴い、以下の変更を加える。
- イベント引数を整理した`EchonetPropertyValueUpdatedEventArgs`を追加する
- ECHONET Lite仕様では実行環境のタイムゾーン情報・オフセット情報の規定がなく、暗黙的にすべて同一タイムゾーン内の時刻・ローカル時刻であると仮定されるため、`EchonetProperty.LastUpdatedTime`の型もDateTimeで扱うように変更する
